### PR TITLE
Fix buffer overflow in buildboardinfodialog()

### DIFF
--- a/src/dialogs/infobox.c
+++ b/src/dialogs/infobox.c
@@ -144,7 +144,7 @@ void editboardinfo(ZZTworld* myworld, displaymethod* d)
 
 dialog buildboardinfodialog(ZZTworld * myworld)
 {
-	char buffer[20];   /* Number to string buffer */
+	char buffer[24];   /* Number to string buffer */
 	int curboard = zztBoardGetCurrent(myworld);
 	int boardsize = zztBoardGetSize(zztBoardGetCurPtr(myworld));
 	dialog dia;
@@ -256,7 +256,7 @@ dialog buildboardinfodialog(ZZTworld * myworld)
 	} else {
 		_addoption("(None)", BRDINFO_BRDWEST);
 	}
-	
+
 	/* Board size statistics */
 
 	label.x = 4; _addlabel("Board Size:");
@@ -898,5 +898,3 @@ void worldflagclear(int curoption, ZZTworld* myworld)
 	/* Very nice */
 	zztWorldSetFlag(myworld, curoption, "");
 }
-
-


### PR DESCRIPTION
The board size message can be up to 22 characters long, which causes a buffer overflow when `sprintf()` writes into `buffer[20]`. When built on Ubuntu 16.04 LTS with default settings, glibc detects this at runtime and terminates KevEdit with "buffer overflow detected".

This commit increases `buffer`'s size to 24 bytes, just to have a round number.