### PR TITLE
Minor cosmetic fixes, workaround for 32nd triplet drum playback crashes

### DIFF
--- a/src/libzzt2/tiles.c
+++ b/src/libzzt2/tiles.c
@@ -703,7 +703,7 @@ uint8_t _zzt_display_char_line(ZZTblock * block, int x, int y)
 	if (x == block->width - 1 || neighbortype == ZZT_LINE || neighbortype == ZZT_EDGE)
 		flags |= 8;
 
-	return _zzt_display_char_line_table[flags];	
+	return _zzt_display_char_line_table[flags];
 }
 
 uint8_t zztLoneTileGetDisplayChar(ZZTtile tile)

--- a/src/libzzt2/tiles.c
+++ b/src/libzzt2/tiles.c
@@ -685,16 +685,25 @@ uint8_t _zzt_display_char_line(ZZTblock * block, int x, int y)
 
 	flags = 0;
 
-	if (y == 0 || (zztTileAt(block, x, y - 1).type == ZZT_LINE))
+	uint8_t neighbortype;
+
+	neighbortype = zztTileAt(block, x, y - 1).type;
+	if (y == 0 || neighbortype == ZZT_LINE || neighbortype == ZZT_EDGE)
 		flags |= 1;
-	if (y == block->height - 1 || (zztTileAt(block, x, y + 1).type == ZZT_LINE))
+           
+	neighbortype = zztTileAt(block, x, y + 1).type;
+	if (y == block->height - 1 || neighbortype == ZZT_LINE || neighbortype == ZZT_EDGE)
 		flags |= 2;
-	if (x == 0 || (zztTileAt(block, x - 1, y).type == ZZT_LINE))
+           
+	neighbortype = zztTileAt(block, x - 1, y).type;
+	if (x == 0 || neighbortype == ZZT_LINE || neighbortype == ZZT_EDGE)
 		flags |= 4;
-	if (x == block->width - 1 || (zztTileAt(block, x + 1, y).type == ZZT_LINE))
+           
+	neighbortype = zztTileAt(block, x + 1, y).type;
+	if (x == block->width - 1 || neighbortype == ZZT_LINE || neighbortype == ZZT_EDGE)
 		flags |= 8;
 
-	return _zzt_display_char_line_table[flags];
+	return _zzt_display_char_line_table[flags];	
 }
 
 uint8_t zztLoneTileGetDisplayChar(ZZTtile tile)

--- a/src/libzzt2/zztoop.c
+++ b/src/libzzt2/zztoop.c
@@ -716,7 +716,7 @@ const char * zztoopflags[ZOOPFLAGCOUNT] =
 
 const char * zztoopitems[ZOOPITEMCOUNT] =
 {
-	"ammo", "gems", "torches", "health", "score"
+	"ammo", "gems", "torches", "health", "score", "time"
 };
 
 const char * zztoopcolours[ZOOPCOLOURCOUNT] =

--- a/src/libzzt2/zztoop.h
+++ b/src/libzzt2/zztoop.h
@@ -98,7 +98,7 @@ typedef struct ZZTOOPparser {
 #define ZOOPCOMMANDCOUNT    27
 #define ZOOPMESSAGECOUNT     5
 #define ZOOPFLAGCOUNT        5
-#define ZOOPITEMCOUNT        5
+#define ZOOPITEMCOUNT        6
 #define ZOOPCOLOURCOUNT      7
 #define ZOOPDIRCOUNT        15
 #define ZOOPDIRMODCOUNT      4

--- a/src/synth/pcspeaker.c
+++ b/src/synth/pcspeaker.c
@@ -30,6 +30,7 @@ void pcSpeakerPlayNote(musicalNote note, musicSettings settings)
 	int frequency = noteFrequency(note, settings);
 	int wait = noteDuration(note, settings);
 	int spacing = noteSpacing(note, settings);
+	int drumbreaktime = wait - DRUMBREAK * DRUMCYCLES;
 
 	if (note.type == NOTETYPE_NOTE) {
 		/* Play the sound at the frequency for a duration */
@@ -55,7 +56,9 @@ void pcSpeakerPlayNote(musicalNote note, musicSettings settings)
 		nosound();
 
 		/* Add a break based on the current duration */
-		delay(wait - DRUMBREAK * DRUMCYCLES);
+		if( drumbreaktime > 0 ) {
+			delay(drumbreaktime);
+		}
 	}
 
 	if (spacing != 0.0) {

--- a/src/synth/sdl_synth.c
+++ b/src/synth/sdl_synth.c
@@ -100,6 +100,7 @@ void SynthPlayNote(SDL_AudioSpec audiospec, musicalNote note, musicSettings sett
 	if (note.type == NOTETYPE_DRUM) {
 		/* Okay, these drums sound terrible, but they're better than nothing. */
 		int i;
+		float breaktime = wait - ((float)DRUMBREAK) * DRUMCYCLES / 1000;
 
 		/* Loop through each drum cycle */
 		for (i = 0; i < DRUMCYCLES; i++) {
@@ -107,7 +108,9 @@ void SynthPlayNote(SDL_AudioSpec audiospec, musicalNote note, musicSettings sett
 		}
 
 		/* Add a break based on the current duration */
-		AddToBuffer(audiospec, 0, wait - ((float)DRUMBREAK) * DRUMCYCLES / 1000);
+		if( breaktime > 0 ) {
+			AddToBuffer(audiospec, 0, breaktime);
+		}
 	}
 
 	if (spacing != 0.0)


### PR DESCRIPTION
954839a - Linewalls in ZZT attach to edge tiles as though they are lines, including edge tiles that have been placed within the bounds of the board. Added an additional check for ZZT_EDGE neighbors to mirror ZZT behavior.

a7b8a79  - Added "time" to the list of counters so that it displays like health, torches, etc in the edit box.

0ceccf3 and 1761e3b - Prevent KevEdit from segfaulting (SDL) or softlocking (DOS) when a 32nd triplet drum sound is played in the edit box with Ctrl+t. For example, attempting to test "#play 3456" would cause a lock or crash depending on the environment. ZZT itself seems to go silent when playing one of these patterns.