### PR TITLE
Autotools fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,8 +15,7 @@ ICON_SIZES = 16 32 128 256 512
 
 install-icons:
 	for size in $(ICON_SIZES); do \
-		mkdir -p $(datadir)/icons/hicolor/$${size}x$${size}/apps; \
-		$(INSTALL_DATA) $(srcdir)/inst/icon$${size}.png $(datadir)/icons/hicolor/$${size}x$${size}/apps/kevedit.png; \
+		$(INSTALL_DATA) -D $(srcdir)/inst/icon$${size}.png $(DESTDIR)$(datadir)/icons/hicolor/$${size}x$${size}/apps/kevedit.png; \
 	done
 
 uninstall-icons:

--- a/configure.ac
+++ b/configure.ac
@@ -118,7 +118,7 @@ if test "$dosbox" == "yes"; then
 	AC_SUBST(MKISOFS)
 	AC_DEFINE(DOSBOX, [1], [Define to 1 if DOSBox is enabled])
 fi
-AM_CONDITIONAL(WITH_DOSBOX, [test x$dosbox != x])
+AM_CONDITIONAL(WITH_DOSBOX, [test "$dosbox" == yes])
 
 AC_SUBST([display_objects])
 AC_SUBST([synth_objects])


### PR DESCRIPTION
`./configure --without-dosbox` still tries to build the ISO image. This fixes that.
`make install DESTDIR=whatever` still tries to install icons under `$(datadir)`. This fixes that.