### PR TITLE
Preserve filename extensions when saving ZZT worlds

### DIFF
--- a/src/kevedit/misc.c
+++ b/src/kevedit/misc.c
@@ -397,10 +397,12 @@ int saveworld(displaymethod * mydisplay, ZZTworld * myworld)
 	char* path, * file;
 	char* oldfilenamebase;    /* Old filename without extension */
 	char* dotptr;             /* General pointer */
+	char* ext;                /* Extension of file */
 
 	bool quit = false;
+	ext = strrchr(zztWorldGetFilename(myworld), '.') + 1;
 	filename =
-		filenamedialog(zztWorldGetFilename(myworld), "zzt", "Save World As", 1, mydisplay, &quit);
+		filenamedialog(zztWorldGetFilename(myworld), ext, "Save World As", 1, mydisplay, &quit);
 	if (quit)
 		return DKEY_QUIT;
 


### PR DESCRIPTION
Running KevEdit under Linux I frequently run into the issue where opening a world created in the original ZZT editor ends up creating a duplicate copy of the file when saving as the filename goes from "TOWN.ZZT" to "TOWN.zzt". This change gets the extension of the loaded file and uses the existing extension when saving.