### PR TITLE
adjust board size calculation to match ZZT 3.2 expectations

### DIFF
--- a/src/dialogs/infobox.c
+++ b/src/dialogs/infobox.c
@@ -268,7 +268,7 @@ dialog buildboardinfodialog(ZZTworld * myworld)
 
 	label.x = 4; _addlabel("Board Size:");
 	/* Red color for dangerously large board size */
-	label.color = (boardsize < 20000 ? 0x0B : 0x0C);
+	label.color = (boardsize <= ZZT_BOARD_MAX_FILESIZE ? 0x0B : 0x0C);
 	label.y--; label.x = 16;
 
 	sprintf(buffer, "%d bytes, %.3f KB", boardsize, (float)boardsize / 1024);

--- a/src/libzzt2/board.c
+++ b/src/libzzt2/board.c
@@ -440,9 +440,8 @@ uint16_t zztBoardGetSize(ZZTboard *board)
 	uint16_t size = 0;
 	int i;
 
-	size += 0x34; /* Header */
-	size += 0x58; /* Info */
-	size += 1;    /* ? */
+	size += 0x33; /* Board name */
+	size += 0x58; /* Board info */
 
 	/* Size the bigboard */
 	if (board->bigboard != NULL) {

--- a/src/libzzt2/file.c
+++ b/src/libzzt2/file.c
@@ -397,9 +397,9 @@ int zztBoardWrite(ZZTboard *board, FILE *fp)
 		ofs += 3;
 	}
 	size += ofs;	/* Size of packed data */
-	size += 88;	/* Board info */
+	size += 0x58;	/* Board info */
 	for(i = 0; i < board->info.paramcount; i++) {
-		size += 33;			/* Object header */
+		size += 0x21;			/* Object header */
 		size += board->params[i].length;/* Object data */
 	}
 

--- a/src/libzzt2/zzt.h
+++ b/src/libzzt2/zzt.h
@@ -29,6 +29,8 @@ extern "C" {
 
 
 /***** CONSTANTS *****/
+/* Board filesize constants */
+#define ZZT_BOARD_MAX_FILESIZE	20000
 /* Board size constants */
 #define ZZT_BOARD_X_SIZE 	60
 #define ZZT_BOARD_Y_SIZE 	25


### PR DESCRIPTION
* The size of the board save buffer is 20000 bytes, not 19999 bytes.
* The board save buffer does not include the board's size in bytes; therefore, those two bytes do not count for the size limit.

Also made the 20000-byte limit a constant.