### PR TITLE
Fix board deletion crash, board dialog names

### DIFF
--- a/src/dialogs/infobox.c
+++ b/src/dialogs/infobox.c
@@ -304,7 +304,7 @@ int boardinfoeditoption(displaymethod * d, ZZTworld* myworld, dialogComponent* o
 			break;
 
 		case BRDINFO_BRDNORTH: {
-			int board = boarddialog(myworld, zztBoardGetBoard_n(myworld), "Board to the North", 1, d);
+			int board = boarddialog(myworld, zztBoardGetBoard_n(myworld), "Board to the North", BOARDDIALOG_FIRST_NONE, d);
 			if(board == DKEY_QUIT) {
 				return UPDATE_QUIT;
 			} else {
@@ -314,7 +314,7 @@ int boardinfoeditoption(displaymethod * d, ZZTworld* myworld, dialogComponent* o
 		}
 
 		case BRDINFO_BRDSOUTH:{
-			int board = boarddialog(myworld, zztBoardGetBoard_s(myworld), "Board to the North", 1, d);
+			int board = boarddialog(myworld, zztBoardGetBoard_s(myworld), "Board to the South", BOARDDIALOG_FIRST_NONE, d);
 			if(board == DKEY_QUIT) {
 				return UPDATE_QUIT;
 			} else {
@@ -324,7 +324,7 @@ int boardinfoeditoption(displaymethod * d, ZZTworld* myworld, dialogComponent* o
 		}
 
 		case BRDINFO_BRDEAST:{
-			int board = boarddialog(myworld, zztBoardGetBoard_e(myworld), "Board to the North", 1, d);
+			int board = boarddialog(myworld, zztBoardGetBoard_e(myworld), "Board to the East", BOARDDIALOG_FIRST_NONE, d);
 			if(board == DKEY_QUIT) {
 				return UPDATE_QUIT;
 			} else {
@@ -334,7 +334,7 @@ int boardinfoeditoption(displaymethod * d, ZZTworld* myworld, dialogComponent* o
 		}
 
 		case BRDINFO_BRDWEST:{
-			int board = boarddialog(myworld, zztBoardGetBoard_w(myworld), "Board to the North", 1, d);
+			int board = boarddialog(myworld, zztBoardGetBoard_w(myworld), "Board to the West", BOARDDIALOG_FIRST_NONE, d);
 			if(board == DKEY_QUIT) {
 				return UPDATE_QUIT;
 			} else {

--- a/src/kevedit/screen.c
+++ b/src/kevedit/screen.c
@@ -790,7 +790,7 @@ char *titledialog(char* prompt, displaymethod * d, bool *quit)
 	return t;
 }
 
-stringvector buildboardlist(ZZTworld * w, int firstnone)
+stringvector buildboardlist(ZZTworld * w, int flags)
 {
 	stringvector boardlist;
 	int boardcount = zztWorldGetBoardcount(w);
@@ -798,7 +798,7 @@ stringvector buildboardlist(ZZTworld * w, int firstnone)
 
 	initstringvector(&boardlist);
 
-	if (firstnone) {
+	if (flags & BOARDDIALOG_FIRST_NONE) {
 		pushstring(&boardlist, str_dup("(none)"));
 		i = 1;
 	} else {
@@ -816,14 +816,14 @@ stringvector buildboardlist(ZZTworld * w, int firstnone)
 	return boardlist;
 }
 
-int boarddialog(ZZTworld * w, int curboard, char * title, int firstnone, displaymethod * mydisplay)
+int boarddialog(ZZTworld * w, int curboard, char * title, int flags, displaymethod * mydisplay)
 {
 	stringvector boardlist;
 	int boardcount = zztWorldGetBoardcount(w);
 	int response;
 
 	/* Build the list of boards */
-	boardlist = buildboardlist(w, firstnone);
+	boardlist = buildboardlist(w, flags);
 	svmoveby(&boardlist, curboard);
 
 	/* Draw the side panel */
@@ -853,7 +853,8 @@ int boarddialog(ZZTworld * w, int curboard, char * title, int firstnone, display
 					!(src == boardcount - 1 && response == EDITBOX_FORWARD)) {
 				if (response == EDITBOX_BACK) {
 					/* Delete selected board */
-					if (zztWorldGetBoardcount(w) > 1) {
+					if (zztWorldGetBoardcount(w) > 1 &&
+							(src != zztBoardGetCurrent(w) || (flags & BOARDDIALOG_CHANGES_CURRENT_BOARD))) {
 						if (zztWorldDeleteBoard(w, src, 1)) {
 							boardcount = zztWorldGetBoardcount(w);
 							curboard = (boardcount == src ? src - 1 : src);
@@ -867,7 +868,7 @@ int boarddialog(ZZTworld * w, int curboard, char * title, int firstnone, display
 				}
 				/* Rebuild the board list */
 				deletestringvector(&boardlist);
-				boardlist = buildboardlist(w, firstnone);
+				boardlist = buildboardlist(w, flags);
 				svmoveby(&boardlist, curboard);
 			}
 		}
@@ -894,7 +895,7 @@ int boarddialog(ZZTworld * w, int curboard, char * title, int firstnone, display
 
 int switchboard(ZZTworld * w, displaymethod * mydisplay)
 {
-	int newboard = boarddialog(w, zztBoardGetCurrent(w), "Switch Boards", 0, mydisplay);
+	int newboard = boarddialog(w, zztBoardGetCurrent(w), "Switch Boards", BOARDDIALOG_CHANGES_CURRENT_BOARD, mydisplay);
     if(newboard == DKEY_QUIT) {
         return DKEY_QUIT;
     }

--- a/src/kevedit/screen.h
+++ b/src/kevedit/screen.h
@@ -58,6 +58,10 @@
 #define CONFIRM_CANCEL 2
 #define CONFIRM_QUIT   3
 
+/* boarddialog() flags */
+#define BOARDDIALOG_FIRST_NONE 1
+#define BOARDDIALOG_CHANGES_CURRENT_BOARD 2
+
 /* line_editor() - edit a string of characters on a single line
  * 	str:       buffer to be edited
  * 	editwidth: maximum length string in buffer
@@ -105,7 +109,7 @@ char* filenamedialog(char* initname, char* extension, char* prompt,
 
 
 /* board dialogs */
-int boarddialog(ZZTworld * w, int curboard, char * title, int firstnone, displaymethod * mydisplay);
+int boarddialog(ZZTworld * w, int curboard, char * title, int flags, displaymethod * mydisplay);
 int switchboard(ZZTworld * w, displaymethod * mydisplay);
 char *titledialog(char* prompt, displaymethod * d, bool *quit);
 


### PR DESCRIPTION
This commit fixes two bugs:

- Crash when deleting board from sub-dialogs of stats on said board
  (f.e. deleting board A while editing the destination of a passage on board A)
- Incorrect dialog names for non-North board neighbor dialogs

The crash patch simply forbids deleting the board one is currently on from said submenus.