### PR TITLE
Make wordwrap in code editor adjustable again

### DIFF
--- a/src/display/display_sdl.c
+++ b/src/display/display_sdl.c
@@ -617,7 +617,7 @@ void display_end(video_info *vdest)
 		free(display.dropped_file);
 		display.dropped_file = NULL;
 	}
-	
+
 	/* SDL should restore everything okay.. just use SDL_quit() when ready */
 }
 
@@ -683,7 +683,7 @@ static void display_present(video_info *vdest, const SDL_Rect *rect)
 	SDL_RenderClear(vdest->renderer);
 	SDL_RenderCopy(vdest->renderer, vdest->texture, NULL, NULL);
 	SDL_RenderPresent(vdest->renderer);
-	
+
 	if(rect == NULL) {
 		vdest->is_dirty = false;
 	}
@@ -844,7 +844,7 @@ void display_update_and_present(video_info *vdest, int x, int y, int width,
 	bool was_dirty = vdest->is_dirty;
 	display_update(vdest, x, y, width, height);
 	vdest->is_dirty = was_dirty;
-	
+
 	SDL_Rect rect;
 	rect.x = x * 8;
 	rect.y = y * 14;
@@ -1077,7 +1077,7 @@ int display_sdl_getkey()
 	/* Preemptive stuff */
 	if(event.type == SDL_KEYDOWN) {
 		/* Hack for windows: alt+tab will never show up */
-		if((event.key.keysym.sym == SDLK_TAB) && 
+		if((event.key.keysym.sym == SDLK_TAB) &&
 				(event.key.keysym.mod & KMOD_ALT)) {
 			return DKEY_NONE;
 		}
@@ -1242,6 +1242,12 @@ int display_sdl_getkey()
 				break;
 			case DKEY_DOWN:
 				event.key.keysym.sym = DKEY_ALT_DOWN;
+				break;
+			case '-':
+				event.key.keysym.sym = DKEY_ALT_MINUS;
+				break;
+			case '=':
+				event.key.keysym.sym = DKEY_ALT_PLUS;
 				break;
 			case 'i':
 				event.key.keysym.sym = DKEY_ALT_I;

--- a/src/texteditor/texteditor.c
+++ b/src/texteditor/texteditor.c
@@ -393,6 +393,25 @@ int texteditHandleEditKey(texteditor * editor)
 			texteditDelete(editor);
 			break;
 
+		/***** Wrap width *****/
+		case DKEY_ALT_MINUS:
+			if (editor->wrapwidth > 10) {
+				editor->wrapwidth--;
+			} else {
+				editor->wrapwidth = TEXTED_MAXWIDTH;
+			}
+			editor->updateflags |= TUD_PANEL;
+			break;
+
+		case DKEY_ALT_PLUS:
+			if (editor->wrapwidth < TEXTED_MAXWIDTH) {
+				editor->wrapwidth++;
+			} else {
+				editor->wrapwidth = 10;
+			}
+			editor->updateflags |= TUD_PANEL;
+			break;
+
 		/****** Help dialog ******/
 
 		case DKEY_F1: /* F1: help dialog */
@@ -596,7 +615,7 @@ int texteditHelpZOC(texteditor * editor)
 
 		/* Display the help file with the command as the topic */
 		result = helpsectiontopic("langref", command, editor->d);
-		
+
 		free(command);
 	} else {
 		/* Display the oop help file */
@@ -783,7 +802,7 @@ int texteditFileOpen(texteditor * editor, int insertflag)
 {
 	stringvector filetypelist;
 	char* filename = NULL;
-	
+
 	initstringvector(&filetypelist);
 
 	pushstring(&filetypelist, "*.zoc");
@@ -1102,7 +1121,7 @@ int texteditInsertASCII(texteditor * editor)
 {
 	static int selChar; /* TODO: static isn't the way to go, or is it? */
 	int choice;
- 
+
 	editor->updateflags |= TUD_EDITAREA;
 
 	/* TODO: let #char be anywhere on the line */


### PR DESCRIPTION
The adjustable wordwrap feature was broken: pushing the keys listed in
the sidebar (alt-plus, alt-minus) did nothing. This commit allows the
user to specify a custom wordwrap length yet again.

- Update SDL code to pull in DKEY_ALT_MINUS/DKEY_ALT_PLUS
- Copy/translate wordwrap code from editbox.c to texteditor.c