### PR TITLE
Fix some miscellaneous memory leaks

### DIFF
--- a/src/dialogs/files.c
+++ b/src/dialogs/files.c
@@ -39,7 +39,7 @@
 
 #define BUFFERSIZE 42     /* Expanding buffer for text files */
 #define CWDMAXLEN 4096    /* Max to allow getcwd() to reserve */
-#define CPBUFFERSIZE 1024 /* Binary file transfer buffer */ 
+#define CPBUFFERSIZE 1024 /* Binary file transfer buffer */
 
 /***************************************************************************/
 /**** File I/O *************************************************************/
@@ -133,7 +133,7 @@ stringvector filetosvector(char* filename, int wrapwidth, int editwidth)
 	/* remove trailing blank line, if present */
 	v.cur = v.last;
 	if (strlen(v.cur->s) == 0)
-		removestring(&v);
+		deletestring(&v);
 
 	return v;
 }
@@ -347,7 +347,7 @@ copyfile(char* srcname, char* destname, int flags)
 		fprintf(stderr, "Cannot open %s for reading.", srcname);
 		return COPY_BADSOURCE;
 	}
-	
+
 	/* Open the destination file for writing */
 	dest = fopen(destname, "wb");
 	if (dest == NULL) {

--- a/src/dialogs/paramed.c
+++ b/src/dialogs/paramed.c
@@ -237,11 +237,12 @@ ZZTparam svectortoprogram(stringvector sv)
 int editprogram(displaymethod * d, ZZTparam * p)
 {
 	texteditor * editor;
-	stringvector sv;
+	stringvector * sv;
 	ZZTparam newparam;
 
-	sv = programtosvector(p, EDITBOX_ZZTWIDTH);
-	editor = createtexteditor("Program Editor", &sv, d);
+	sv = (stringvector *) malloc(sizeof(stringvector));
+	*sv = programtosvector(p, EDITBOX_ZZTWIDTH);
+	editor = createtexteditor("Program Editor", sv, d);
 
 	/* Now that the node is full, we can edit it. */
 	int result = textedit(editor);

--- a/src/kevedit/menu.c
+++ b/src/kevedit/menu.c
@@ -146,7 +146,7 @@ int creaturemenu(keveditor * myeditor)
 	if (choice != -1) {
 		zztPlot(myworld, myeditor->cursorx, myeditor->cursory, tile);
 		push(myeditor->buffers.backbuffer, tile);
-		
+
 		/* Free our copy of the params */
 		if (tile.param != NULL)
 			zztParamFree(tile.param);
@@ -375,14 +375,13 @@ int objectlibrarymenu(keveditor * myeditor)
 	} while (!ishypermessage(menu));
 
 	choice = gethypermessage(menu);
-
-
 	if (str_equ(choice, "load", 0))
 		result = loadobjectlibrary(myeditor);
 	else if (str_equ(choice, "save", 0))
 		result = saveobjecttolibrary(myeditor);
 	else if (str_equ(choice, "new", 0))
 		result = saveobjecttonewlibrary(myeditor);
+	free(choice);
 
 	removestringvector(&menu);
     return result;

--- a/src/texteditor/texteditor.c
+++ b/src/texteditor/texteditor.c
@@ -180,6 +180,7 @@ void deletetexteditortext(texteditor * editor)
 
 	deletestringvector(editor->text);
 
+	free(editor->text);
 	editor->text = NULL;
 }
 

--- a/src/texteditor/zzl.c
+++ b/src/texteditor/zzl.c
@@ -70,7 +70,7 @@ int zzlpickobject(stringvector * zzlv, displaymethod * d)
 	} while (finder != NULL);
 
 	result = scrolldialog("Select An Object", &namelist, d);
-	
+
 	if (result == EDITBOX_OK) {
 		finder = zzlv->first->next;
 		while (finder != NULL && finder->s != namelist.cur->s)
@@ -124,6 +124,7 @@ ZZTtile zzlpullobject(stringvector zzlv, int x, int y, int undert, int underc)
 	}
 
 	objcodeparam = svectortoprogram(objectcode);
+	deletestringvector(&objectcode);
 
 	/* Create the new pattern definition */
 	result.type = ZZT_OBJECT;
@@ -182,7 +183,7 @@ int zzlappendobject(stringvector * zzlv, ZZTtile obj, char* title, int editwidth
 
 	pushstring(zzlv, str_dupmin(title, editwidth));
 	pushstring(zzlv, str_dupmin(buffer, editwidth));
-	
+
 	stringvectorcat(zzlv, &objcode);
 
 	return 0;

--- a/src/texteditor/zzm.c
+++ b/src/texteditor/zzm.c
@@ -159,7 +159,8 @@ int zzmpicksong(stringvector * zzmv, displaymethod * d)
 	/* determine the number chosen */
 	sscanf(songtitles.cur->s, "%*c%d", &i);
 
-	deletestringvector(&songtitles);
+	deletestringvector(&songtitles); // free nodes and their strings
+	removestringvector(&rawtitles); // free nodes only (string memory belongs to zzmv)
 
 	return i;
 }


### PR DESCRIPTION
Found these while playing around with Valgrind. I broke them out into conceptually-related commits:

- Fix memory leak in deletetexteditortext(): this one has more info in [the commit message](https://github.com/cknave/kevedit/commit/6ccd769b5de1511984445b924bdafb27b236d9c5).
- Fix some miscellaneous memory leaks in ZZL code
- Fix memory leak in ZZM song picker