### PR TITLE
support GLOB_INTERFACE_VERSION = 2 for system-provided glob

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,10 +152,9 @@ AC_CACHE_CHECK([if system libc has GNU glob], [make_cv_sys_gnu_glob],
 #include <glob.h>
 #include <fnmatch.h>
 
-#define GLOB_INTERFACE_VERSION 1
 #if !defined _LIBC && defined __GNU_LIBRARY__ && __GNU_LIBRARY__ > 1
 # include <gnu-versions.h>
-# if _GNU_GLOB_INTERFACE_VERSION == GLOB_INTERFACE_VERSION
+# if _GNU_GLOB_INTERFACE_VERSION == 1 || _GNU_GLOB_INTERFACE_VERSION == 2
    gnu glob
 # endif
 #endif],


### PR DESCRIPTION
The reason for the bump in version number is outlined in [this bug report](https://sourceware.org/bugzilla/show_bug.cgi?id=22183); particularly, allowing "glob" to match dangling symlinks caused an incompatibility in GNUmake.

Feel free to review it and decide whether or not that may also break KevEdit, and - as such - whether this pull request is valid or needs additional work.