### PR TITLE
Assorted world/board save fixes.

### DIFF
--- a/src/dialogs/infobox.c
+++ b/src/dialogs/infobox.c
@@ -154,7 +154,7 @@ dialog buildboardinfodialog(ZZTworld * myworld)
 {
 	char buffer[24];   /* Number to string buffer */
 	int curboard = zztBoardGetCurrent(myworld);
-	int boardsize = zztBoardGetSize(zztBoardGetCurPtr(myworld));
+	uint32_t boardsize = zztBoardGetSize(zztBoardGetCurPtr(myworld));
 	dialog dia;
 
 	dialogComponent label  = dialogComponentMake(DIALOG_COMP_LABEL,   3, 2, LABEL_COLOR,  NULL, ID_NONE);

--- a/src/kevedit/misc.c
+++ b/src/kevedit/misc.c
@@ -54,6 +54,53 @@
 #include "zlaunch/dosbox.h"
 #endif
 
+static char * save_backup_begin(char * filename) {
+	char * bkp_filename;
+	int pos;
+
+	if (filename[0] == '\0') {
+		return str_dup(filename);
+	}
+
+#ifdef DOS
+	/* Do not assume LFN on DOS. */
+	bkp_filename = str_dup(filename);
+	bkp_filename[0] = '~';
+#else
+	bkp_filename = str_dupadd(filename, 4);
+	strcat(bkp_filename, ".BAK");
+	if (fileexists(bkp_filename)) {
+		pos = strlen(bkp_filename) - 1;
+		bkp_filename[pos] = '1';
+		while (fileexists(bkp_filename) && bkp_filename[pos] < '9') {
+			bkp_filename[pos]++;
+		}
+	}
+#endif
+
+	if (!fileexists(bkp_filename))
+		if (!fileexists(filename) || (rename(filename, bkp_filename) == 0))
+			return bkp_filename;
+
+	free(bkp_filename);
+	return NULL;
+}
+
+static void save_backup_end(char * filename, char * bkp_filename, bool success) {
+	if (bkp_filename == NULL) {
+		return;
+	}
+
+	if (success) {
+		remove(bkp_filename);
+	} else {
+		remove(filename);
+		rename(bkp_filename, filename);
+	}
+
+	free(bkp_filename);
+}
+
 void copy(keveditor * myeditor)
 {
 	/* Only copy if a block is selected */
@@ -394,10 +441,12 @@ int saveworld(displaymethod * mydisplay, ZZTworld * myworld)
 {
 	/* Save World after prompting user for filename */
 	char* filename;
+	char* bkp_filename;
 	char* path, * file;
 	char* oldfilenamebase;    /* Old filename without extension */
 	char* dotptr;             /* General pointer */
 	char* suggestext;         /* Suggested extension */
+	int result;
 
 	if (zztWorldGetFilename(myworld) != NULL) {
 		suggestext = strrchr(zztWorldGetFilename(myworld), '.');
@@ -452,7 +501,12 @@ int saveworld(displaymethod * mydisplay, ZZTworld * myworld)
 	/* Set the current board as the starting board */
 	zztWorldSetStartboard(myworld, zztBoardGetCurrent(myworld));
 
-	zztWorldSave(myworld);
+	result = 0;
+	bkp_filename = save_backup_begin(filename);
+	if (bkp_filename != NULL) {
+		result = zztWorldSave(myworld);
+		save_backup_end(filename, bkp_filename, result > 0);
+	}
 
 	free(oldfilenamebase);
 	oldfilenamebase = NULL;
@@ -461,8 +515,8 @@ int saveworld(displaymethod * mydisplay, ZZTworld * myworld)
 	free(path);
 	free(file);
 
-	mydisplay->print(61, 5, 0x1f, "Written.");
-	mydisplay->cursorgo(69, 5);
+	mydisplay->print(61, 5, result > 0 ? 0x1f : 0x1c, result > 0 ? "Written." : "Write error!");
+	mydisplay->cursorgo(result > 0 ? 69 : 73, 5);
 	return mydisplay->getch();
 }
 
@@ -627,8 +681,10 @@ int importfromboard(displaymethod * mydisplay, ZZTworld * myworld)
 int exporttoboard(displaymethod * mydisplay, ZZTworld * myworld)
 {
 	char* filename;
+	char* bkp_filename;
 	ZZTboard* brd;
 	bool quit = false;
+	int result;
 
 	/* Prompt for a filename */
 	filename = filenamedialog("", ".brd", "Export to Board", 1, mydisplay, &quit);
@@ -642,7 +698,18 @@ int exporttoboard(displaymethod * mydisplay, ZZTworld * myworld)
 	brd = zztBoardGetCurPtr(myworld);
 
 	/* Export */
-	zztBoardSave(brd, filename);
+	result = 0;
+	bkp_filename = save_backup_begin(filename);
+	if (bkp_filename != NULL) {
+		result = zztBoardSave(brd, filename);
+		save_backup_end(filename, bkp_filename, result > 0);
+	}
+
+	if (result <= 0) {
+		mydisplay->print(61, 5, 0x1c, "Write error!");
+		mydisplay->cursorgo(73, 5);
+		mydisplay->getch();
+	}
 
 	/* Decompress; it is the current board, after all */
 	zztBoardDecompress(brd);

--- a/src/kevedit/misc.c
+++ b/src/kevedit/misc.c
@@ -56,6 +56,9 @@
 
 static char * save_backup_begin(char * filename) {
 	char * bkp_filename;
+#ifdef DOS
+	char * bkp_filename_start;
+#endif
 	int pos;
 
 	if (filename[0] == '\0') {
@@ -65,7 +68,12 @@ static char * save_backup_begin(char * filename) {
 #ifdef DOS
 	/* Do not assume LFN on DOS. */
 	bkp_filename = str_dup(filename);
-	bkp_filename[0] = '~';
+	bkp_filename_start = strrchr(bkp_filename, '/');
+	if (bkp_filename_start != NULL)
+		bkp_filename_start++;
+	else
+		bkp_filename_start = bkp_filename;
+	bkp_filename_start[0] = '~';
 #else
 	bkp_filename = str_dupadd(filename, 4);
 	strcat(bkp_filename, ".BAK");

--- a/src/libzzt2/board.c
+++ b/src/libzzt2/board.c
@@ -435,9 +435,9 @@ int zztBoardCompress(ZZTboard *board)
 	return 1;
 }
 
-uint16_t zztBoardGetSize(ZZTboard *board)
+uint32_t zztBoardGetSize(ZZTboard *board)
 {
-	uint16_t size = 0;
+	uint32_t size = 0;
 	int i;
 
 	size += 0x33; /* Board name */

--- a/src/libzzt2/file.c
+++ b/src/libzzt2/file.c
@@ -383,7 +383,7 @@ boardReadDone:
 
 int zztBoardWrite(ZZTboard *board, FILE *fp)
 {
-	uint16_t size;
+	uint32_t size;
 	uint16_t w;
 	uint8_t b;
 	int i, ofs;
@@ -403,8 +403,14 @@ int zztBoardWrite(ZZTboard *board, FILE *fp)
 		size += board->params[i].length;/* Object data */
 	}
 
+	/* Completely forbid saving boards which go over the 16-bit length */
+	if (size > 65535) {
+		return 0;
+	}
+
 	/* Write board header */
-	_zzt_outw_ordie(&size, fp);
+	w = size;
+	_zzt_outw_ordie(&w, fp);
 	b = strlen((char *)board->title);
 	if (b > ZZT_BOARD_TITLE_SIZE)
 		b = ZZT_BOARD_TITLE_SIZE;

--- a/src/libzzt2/strtools.h
+++ b/src/libzzt2/strtools.h
@@ -33,9 +33,10 @@ extern "C" {
 
 /* String duplication using malloc
  * str_dup()    - reserves just enough space for the string
- * str_dupmax() - reserves at  most max+1 space
  * str_dupmin() - reserves at least min+1 space
- * str_dupat()  - reserves  exactly len+1 space
+ * str_dupmax() - reserves at  most max+1 space
+ * str_duplen() - reserves  exactly len+1 space
+ * str_dupadd() - reserves just enough space for the string + add chars
  */
 char * str_dup   (char * s);
 char * str_dupmin(char * s, unsigned int min);

--- a/src/libzzt2/world.c
+++ b/src/libzzt2/world.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "strtools.h"
 #include "zzt.h"
 
 ZZTworld *zztWorldCreate(char *filename, char *title)
@@ -55,13 +56,7 @@ ZZTworld *zztWorldCreate(char *filename, char *title)
 	world->boards = zztBoardCreate("Title screen");
 	world->header->boardcount = 1;
 	/* Filename = given or untitled.zzt */
-	if(filename != NULL) {
-		world->filename = malloc(strlen(filename)+1);
-		strcpy(world->filename, filename);
-	} else {
-		world->filename = malloc(strlen("untitled.zzt")+1);
-		strcpy(world->filename, "untitled.zzt");
-	}
+	world->filename = str_dup(filename != NULL ? filename : "untitled.zzt");
 	/* Decompress the current/first board */
 	world->cur_board = 0;
 	zztBoardDecompress(&(world->boards[0]));

--- a/src/libzzt2/zzt.h
+++ b/src/libzzt2/zzt.h
@@ -325,7 +325,7 @@ int zztBoardCompress(ZZTboard *board);
 /* zztBoardGetSize(board)
  * Determine the size of a board in bytes
  */
-uint16_t zztBoardGetSize(ZZTboard *board);
+uint32_t zztBoardGetSize(ZZTboard *board);
 /* zztWorldAddBoard(world, title)
  * Create a blank board at the end of the world with the given title
  */


### PR DESCRIPTION
* Added backup system. Now, when a world is being saved, it is first renamed
  (to f.e. UNTITLED.ZZT.BAK), then saved, then the backup is removed only if
  the saving process was successful. This means that in the event of edge
  cases causing the save to fail (see below) or KevEdit crashes ~~(as Dr_Dos
  and myself have recently encountered but not reproduced)~~, the world data
  should be safe. Note that I did not make it configurable, at this time.
* Fixed board size information for boards over 65535 bytes. (For example, try
  placing an object with a fair amount of text, and filling the board with
  it - it can easily go into the hundreds of kilobytes.)
* Saving boards and worlds above 65535 bytes is now strictly forbidden and
  will cause an error - it is not possible to save such a world uncorrupted
  in the ZZT world format, due to the 16-bit board size limit.
* Errors are now caught and the user is notified about them during board
  and world saving.
* Minor cleanups around str_dup's documentation and usage.

~~I would consider the backup system workaround critical enough to justify a new release.~~

EDIT: The backup system is no longer strictly mandatory as the bug has been fixed. However, there can be new issues at any time - so it might be good to add as a fallback.