### PR TITLE
Adjust limit to 151 stats with disclaimer as per ZZT 3.2 behaviour.

### DIFF
--- a/docs/kbasics.hlp
+++ b/docs/kbasics.hlp
@@ -79,10 +79,16 @@ you how many PARAMETER RECORDS are stored
 on this board.  Parameter records store
 information for configurable things:
 objects, scrolls, and enemies all have
-parameter records.  ZZT has a limit of 150
-records per board.  Keep an eye on how
-many you have used so that you don't run
-out!
+parameter records.
+
+ZZT has a limit of 150 records per board.
+Keep an eye on how many you have used so
+that you don't run out! (Technically, the
+engine will allow you to have 151 records
+on a board - but the limit for things like
+spawning bullets  or stars is still 150.
+KevEdit will mark this with a yellow '!'
+next to the record count.)
 
 The next line displays the title of the
 world, which can be modified in the

--- a/docs/ktileinf.hlp
+++ b/docs/ktileinf.hlp
@@ -88,7 +88,7 @@ are often called Black Holes. Giving stats
 to other tiles that usually do not have
 them does not generally affect their
 behavior. Remember that each board can
-only have 150 tiles with stats.
+only have 150 (151) tiles with stats.
 
 :sindex;Stat Index
 

--- a/src/kevedit/screen.c
+++ b/src/kevedit/screen.c
@@ -423,7 +423,7 @@ void updatepanel(keveditor * e)
 {
 	displaymethod * d = e->mydisplay;
 	ZZTworld * w = e->myworld;
-	int i, x;
+	int i, x, xtmp;
 	char s[255];
 	char * title = (char *)zztWorldGetTitle(w);
 	int uf = e->updateflags;
@@ -440,10 +440,15 @@ void updatepanel(keveditor * e)
 		d->putch_discrete(63, 0, ' ', 0x1f);
 		d->putch_discrete(76, 0, ' ', 0x1f);
 		d->putch_discrete(77, 0, ' ', 0x1f);
-		sprintf(s, "(%d, %d) %d/150", e->cursorx + 1, e->cursory + 1, zztBoardGetParamcount(w) - 1);
+		d->putch_discrete(78, 0, ' ', 0x1f);
+		xtmp = zztBoardGetParamcount(w) - 1;
+		sprintf(s, "(%d, %d) %d/150", e->cursorx + 1, e->cursory + 1, xtmp);
 		i = 70 - strlen(s) / 2;
-		for (x = 0; x < strlen(s); x++) {
-			d->putch_discrete(i + x, 0, s[x], 0x1c);
+		for (x = 0; x < strlen(s); i++, x++) {
+			d->putch_discrete(i, 0, s[x], 0x1c);
+		}
+		if (xtmp > 150) {
+			d->putch_discrete(i, 0, '!', 0x1e);
 		}
 
 		if (uf & (UD_WORLDTITLE & ~UD_PANEL_TOP)) {

--- a/src/libzzt2/zzt.h
+++ b/src/libzzt2/zzt.h
@@ -38,7 +38,7 @@ extern "C" {
 /* Board title size */
 #define ZZT_BOARD_TITLE_SIZE	50
 /* Maximum params for a board */
-#define ZZT_BOARD_MAX_PARAMS 150
+#define ZZT_BOARD_MAX_PARAMS 151
 /* World title size */
 #define ZZT_WORLD_TITLE_SIZE	20
 /* Flag size */


### PR DESCRIPTION
If you check the Reconstruction's source code, the Stats array actually has a size of 0 to MAX_STAT+1, or 151. While ZZT's bound checks all assume 150 stats, it is as such "legal" in terms of engine behaviour to have a board with 151 stats - however, you'll still need to drop down to 149 stats or lower to add new stats.

I propose making this behaviour documented and visible in KevEdit in the manner as described in the pull request.