### PR TITLE
Audio synthesizer fixes, close #9

### DIFF
--- a/src/synth/notes.h
+++ b/src/synth/notes.h
@@ -1,4 +1,4 @@
-/* notes.h	-- Generate musical notes in chromatic scale
+/* notes.h	-- Generate musical notes
  * $Id: notes.h,v 1.2 2005/06/29 03:20:34 kvance Exp $
  * Copyright (C) 2002 Kev Vance <kvance@kvance.com>
  *
@@ -20,6 +20,9 @@
 #ifndef _NOTES_H
 #define _NOTES_H 1
 
+#include <stdbool.h>
+#include <stdint.h>
+
 /* Note types */
 #define NOTETYPE_NONE 0   /* Usually end-of-input */
 #define NOTETYPE_NOTE 1   /* Just a note */
@@ -27,13 +30,12 @@
 #define NOTETYPE_DRUM 3   /* Tick-tock */
 
 /* Note lengths */
-#define NOTELEN_WHOLE        0x01
-#define NOTELEN_HALF         0x02
-#define NOTELEN_QUARTER      0x04
-#define NOTELEN_EIGHTH       0x08
-#define NOTELEN_SIXTEENTH    0x10
-#define NOTELEN_THIRTYSECOND 0x20
-#define NOTELEN_TRIPLET      0x100  /* Flag: divide duration by 3 */
+#define NOTELEN_WHOLE        0x20
+#define NOTELEN_HALF         0x10
+#define NOTELEN_QUARTER      0x08
+#define NOTELEN_EIGHTH       0x04
+#define NOTELEN_SIXTEENTH    0x02
+#define NOTELEN_THIRTYSECOND 0x01
 
 /* Note indexes */
 #define NOTE_C   0
@@ -49,19 +51,15 @@
 #define NOTE_As 10
 #define NOTE_B  11
 
-/* Pitch of A in octave 0 (where middle C is) */
-#define BASE_PITCH  440
-
 /* Drum information */
-#define DRUMBREAK  2  /* 2 millisecond delay between drum changes */ 
+#define DRUMBREAK  1  /* 1 millisecond delay between drum changes */
 #define DRUMCOUNT  10 /* 10 drums in all */
-#define DRUMCYCLES 10 /* 10 cycles per drum */
+#define DRUMCYCLES 14 /* 14 cycles per drum */
 extern short drums[DRUMCOUNT][DRUMCYCLES];
 
 typedef struct musicalNote {
 	int type;       /* Type of note */
-	int length;     /* Note length */
-	int dots;       /* Number of times a note length is dotted */
+	uint8_t length;     /* Note length */
 	int index;      /* Frequency index or drum index */
 	int octave;     /* Octave of note (0 is middle octave) */
 	int slur;       /* TRUE if note is to slur/tie with the next */
@@ -71,8 +69,8 @@ typedef struct musicalNote {
 } musicalNote;
 
 typedef struct musicSettings {
-	/* Frequency of A in octave 0 (where middle C is) */
-	float basePitch;
+	/* If true, apply PIT-style rounding. */
+	bool pitRounding;
 
 	/* Duration of a whole note, in milliseconds */
 	float wholeDuration;
@@ -83,6 +81,9 @@ typedef struct musicSettings {
 
 /* Delete a chain of notes */
 void deleteNoteChain(musicalNote* chain);
+
+/* Apply filters to a given frequency. */
+float noteFilter(float freq, musicSettings settings);
 
 /* Return the frequency of a given musical note. */
 float noteFrequency(musicalNote mnote, musicSettings settings);

--- a/src/synth/play.c
+++ b/src/synth/play.c
@@ -40,6 +40,7 @@ void printNoteData(musicalNote note, musicSettings settings)
 
 #ifdef SDL
 SDL_AudioSpec spec;
+SDL_AudioDeviceID audioid;
 #endif
 
 void start() {
@@ -48,7 +49,7 @@ void start() {
 
 	atexit(SDL_Quit);
 
-	OpenSynth(&spec);
+	OpenSynth(&audioid, &spec);
 #endif
 }
 
@@ -56,7 +57,7 @@ void end() {
 #ifdef SDL
 	while (!IsSynthBufferEmpty())
 		;
-	CloseSynth();
+	CloseSynth(&audioid);
 	SDL_Quit();
 #elif defined DOS
 	pcSpeakerFinish();

--- a/src/synth/sdl_synth.c
+++ b/src/synth/sdl_synth.c
@@ -33,7 +33,7 @@
 Uint8 *masterplaybuffer = NULL;
 static size_t playbuffersize = 0, playbufferloc = 0, playbuffermax = 0;
 
-int OpenSynth(SDL_AudioSpec * spec)
+int OpenSynth(SDL_AudioDeviceID * id, SDL_AudioSpec * spec)
 {
 	SDL_AudioSpec desired, obtained;
 
@@ -46,6 +46,7 @@ int OpenSynth(SDL_AudioSpec * spec)
 	}
 
 	/* Set desired sound opts */
+	memset(&desired, 0, sizeof(SDL_AudioSpec));
 	desired.freq = 44100;
 	desired.format = AUDIO_U16SYS;
 	desired.channels = 1;
@@ -54,22 +55,23 @@ int OpenSynth(SDL_AudioSpec * spec)
 	desired.userdata = spec;
 
 	/* Open audio device */
-	if(SDL_OpenAudio(&desired, &obtained) < 0) {
+	*id = SDL_OpenAudioDevice(NULL, 0, &desired, &obtained, 0);
+	if (*id == 0) {
 		fprintf(stderr, "SDL Error: %s\n", SDL_GetError());
 		return 1;
 	}
-	SDL_PauseAudio(0);
+	SDL_PauseAudioDevice(*id, 0);
 
 	(*spec) = obtained;
 
 	return 0;
 }
 
-void CloseSynth(void)
+void CloseSynth(SDL_AudioDeviceID * id)
 {
 	/* Silence, close the audio, and clean up the memory we used. */
-	SDL_PauseAudio(1);
-	SDL_CloseAudio();
+	SDL_PauseAudioDevice(*id, 1);
+	SDL_CloseAudioDevice(*id);
 
 	AudioCleanUp();
 }

--- a/src/synth/sdl_synth.c
+++ b/src/synth/sdl_synth.c
@@ -82,18 +82,19 @@ int IsSynthBufferEmpty()
 void SynthPlayNote(SDL_AudioSpec audiospec, musicalNote note, musicSettings settings)
 {
 	/* Find the frequency and duration (wait) in seconds */
-	float frequency = noteFrequency(note, settings);
+	float frequency = noteFilter(noteFrequency(note, settings), settings);
 	float wait    = noteDuration(note, settings) / 1000;
 	float spacing = noteSpacing(note, settings) / 1000;
+	size_t j = 0;
 
 	if (note.type == NOTETYPE_NOTE) {
 		/* Add the sound to the buffer */
-		AddToBuffer(audiospec, frequency, wait);
+		AddToBuffer(audiospec, frequency, wait, &j);
 	}
 
 	/* Rests are simple */
 	if (note.type == NOTETYPE_REST) {
-		AddToBuffer(audiospec, 0, wait);
+		AddToBuffer(audiospec, 0, wait, &j);
 	}
 
 	/* Drums */
@@ -104,26 +105,26 @@ void SynthPlayNote(SDL_AudioSpec audiospec, musicalNote note, musicSettings sett
 
 		/* Loop through each drum cycle */
 		for (i = 0; i < DRUMCYCLES; i++) {
-			AddToBuffer(audiospec, drums[note.index][i], ((float)DRUMBREAK) / 1000);
+			AddToBuffer(audiospec, noteFilter(drums[note.index][i], settings), ((float)DRUMBREAK) / 1000, &j);
 		}
 
 		/* Add a break based on the current duration */
 		if( breaktime > 0 ) {
-			AddToBuffer(audiospec, 0, breaktime);
+			AddToBuffer(audiospec, 0, breaktime, &j);
 		}
 	}
 
 	if (spacing != 0.0)
-		AddToBuffer(audiospec, 0, spacing);
+		AddToBuffer(audiospec, 0, spacing, &j);
 }
 
-void AddToBuffer(SDL_AudioSpec spec, float freq, float seconds)
+void AddToBuffer(SDL_AudioSpec spec, float freq, float seconds, size_t *j_global)
 {
 	size_t notesize = seconds * spec.freq; /* Bytes of sound */
 	size_t wordsize;
 	size_t i, j;
 
-	int osc = 1;
+	int osc;
 
 	Uint16 uon = U16_1, uoff = U16_0;
 	Sint16 son = S16_1, soff = S16_0;
@@ -165,12 +166,13 @@ void AddToBuffer(SDL_AudioSpec spec, float freq, float seconds)
 		playbuffermax += notesize*wordsize;
 	} else {
 		/* Tone */
-		float hfreq = (spec.freq/freq/2.0);
-		for(i = 0, j = 0; i < notesize; i++, j++) {
-			if(j >= hfreq) {
-				osc ^= 1;
-				j = 0;
+		float ffreq = (spec.freq/freq);
+		float hfreq = (ffreq/2.0);
+		for(i = 0, j = (j_global == NULL ? 0 : *j_global); i < notesize; i++, j++) {
+			while (j >= ffreq) {
+				j -= ffreq;
 			}
+			osc = j >= hfreq;
 			if(spec.format == AUDIO_U8) {
 				if(osc)
 					masterplaybuffer[playbuffermax] = U8_1;
@@ -194,6 +196,8 @@ void AddToBuffer(SDL_AudioSpec spec, float freq, float seconds)
 			}
 			playbuffermax += wordsize;
 		}
+		if (j_global != NULL)
+			*j_global = j;
 	}
 
 	/* Now let AudioCallback do its work */

--- a/src/synth/sdl_synth.h
+++ b/src/synth/sdl_synth.h
@@ -37,10 +37,10 @@
 /* TODO: rename these functions */
 
 /* Open the synthesizer and store audio spec in "spec" (true on error) */
-int OpenSynth(SDL_AudioSpec * spec);
+int OpenSynth(SDL_AudioDeviceID *id, SDL_AudioSpec * spec);
 
 /* Close the synthesizer */
-void CloseSynth(void);
+void CloseSynth(SDL_AudioDeviceID *id);
 
 /* Returns true if the buffer is empty */
 int IsSynthBufferEmpty();

--- a/src/synth/sdl_synth.h
+++ b/src/synth/sdl_synth.h
@@ -50,7 +50,7 @@ void SynthPlayNote(SDL_AudioSpec audiospec, musicalNote note, musicSettings sett
 
 /* Add a frequency and duration to the SDL audio
  * buffer */
-void AddToBuffer(SDL_AudioSpec spec, float freq, float seconds);
+void AddToBuffer(SDL_AudioSpec spec, float freq, float seconds, size_t *counter);
 
 /* Internal audio callback function (don't call manually!) */
 void AudioCallback(void *userdata, Uint8 *stream, int len);

--- a/src/synth/zzm.c
+++ b/src/synth/zzm.c
@@ -46,7 +46,6 @@ musicalNote zzmGetDefaultNote(void)
 
 	note.type   = NOTETYPE_NONE;
 	note.length = NOTELEN_THIRTYSECOND;
-	note.dots   = 0;
 	note.index  = 0;
 	note.octave = 0;
 	note.slur   = 1;
@@ -59,7 +58,7 @@ musicalNote zzmGetDefaultNote(void)
 musicSettings zzmGetDefaultSettings(void)
 {
 	musicSettings settings;
-	settings.basePitch = ZZM_BASE_PITCH;
+	settings.pitRounding = true;
 	settings.wholeDuration = 1760;
 	settings.noteSpacing = 8;
 
@@ -76,10 +75,6 @@ musicalNote zzmGetNote(char* tune, musicalNote previousNote)
 		/* Uppercase any characters */
 		curCh = toupper(curCh);
 
-		/* If curCh is a duration character, reset the dots counter */
-		if (strchr("TSIQHW", curCh))
-			note.dots = 0;
-
 		switch (curCh) {
 			/* alter the current duration if we encounter one of these */
 			case 'T': note.length  = NOTELEN_THIRTYSECOND; break; /* (default duration) */
@@ -88,8 +83,8 @@ musicalNote zzmGetNote(char* tune, musicalNote previousNote)
 			case 'Q': note.length  = NOTELEN_QUARTER; break;
 			case 'H': note.length  = NOTELEN_HALF; break;
 			case 'W': note.length  = NOTELEN_WHOLE; break;
-			case '3': note.length |= NOTELEN_TRIPLET; break;
-			case '.': note.dots++; break;   /* Note is dotted */
+			case '3': note.length /= 3; break;
+			case '.': note.length = note.length * 3 / 2; break;   /* Note is dotted */
 			/* octave modifiers */
 			case '+': if (note.octave < ZZM_MAXOCTAVE) note.octave++; break;
 			case '-': if (note.octave > ZZM_MINOCTAVE) note.octave--; break;

--- a/src/synth/zzm.h
+++ b/src/synth/zzm.h
@@ -25,10 +25,6 @@
 #define ZZM_MAXOCTAVE  3
 #define ZZM_MINOCTAVE -2
 
-/* In real music, this is 440. */
-/* In ZZT, it seems to be 432. */
-#define ZZM_BASE_PITCH  432
-
 /* Generate default ZZM note settings */
 musicalNote zzmGetDefaultNote(void);
 

--- a/src/texteditor/editbox.c
+++ b/src/texteditor/editbox.c
@@ -1030,10 +1030,11 @@ void testMusic(stringvector* sv, int slur, int editwidth, int flags, displaymeth
 {
 	int done;
 #ifdef SDL
+	SDL_AudioDeviceID audioid;
 	SDL_AudioSpec spec;
 
 	/* IF opening the audio device fails, return now before we crash something. */
-	if (OpenSynth(&spec))
+	if (OpenSynth(&audioid, &spec))
 		return;
 #endif
 
@@ -1096,7 +1097,7 @@ void testMusic(stringvector* sv, int slur, int editwidth, int flags, displaymeth
 		SDL_Delay(10);
 	}
 
-	CloseSynth();
+	CloseSynth(&audioid);
 #elif defined DOS
 	pcSpeakerFinish();
 #endif

--- a/src/texteditor/editbox.c
+++ b/src/texteditor/editbox.c
@@ -1092,8 +1092,9 @@ void testMusic(stringvector* sv, int slur, int editwidth, int flags, displaymeth
 #ifdef SDL
 	/* TODO: instead of just sitting here, display the progress of playback */
 	/* Wait until the music is done or the user presses a key */
-	while (!IsSynthBufferEmpty() && d->getkey() == DKEY_NONE)
-		;
+	while (!IsSynthBufferEmpty() && d->getkey() == DKEY_NONE) {
+		SDL_Delay(10);
+	}
 
 	CloseSynth();
 #elif defined DOS

--- a/src/texteditor/texteditor.c
+++ b/src/texteditor/texteditor.c
@@ -654,6 +654,7 @@ void texteditZZMPlay(texteditor * editor, int slurflag)
 
 #ifdef SDL
 	SDL_AudioSpec spec;
+	SDL_AudioDeviceID audioid;
 #endif
 
 	/* Display everything, in case the editor has not been displayed recently. */
@@ -661,7 +662,7 @@ void texteditZZMPlay(texteditor * editor, int slurflag)
 
 #ifdef SDL
 	/* IF opening the audio device fails, return now before we crash something. */
-	if (OpenSynth(&spec))
+	if (OpenSynth(&audioid, &spec))
 		return;
 #endif
 
@@ -717,7 +718,7 @@ void texteditZZMPlay(texteditor * editor, int slurflag)
 		SDL_Delay(10);
 	}
 
-	CloseSynth();
+	CloseSynth(&audioid);
 #elif defined DOS
 	pcSpeakerFinish();
 #endif

--- a/src/texteditor/texteditor.c
+++ b/src/texteditor/texteditor.c
@@ -713,8 +713,9 @@ void texteditZZMPlay(texteditor * editor, int slurflag)
 #ifdef SDL
 	/* TODO: instead of just sitting here, display the progress of playback */
 	/* Wait until the music is done or the user presses a key */
-	while (!IsSynthBufferEmpty() && view->d->getkey() == DKEY_NONE)
-		;
+	while (!IsSynthBufferEmpty() && view->d->getkey() == DKEY_NONE) {
+		SDL_Delay(10);
+	}
 
 	CloseSynth();
 #elif defined DOS


### PR DESCRIPTION
Adjusts a lot of code to match both ZZT's parsing and playback expectations. It's not *perfect* to my ears, but it's close enough without throwing out most of the synthesizer code.

In addition, it fixes some non-sound-quality-related bugs:

* Unnecessary CPU usage during playback.
* Sound not working at all on Windows (!?) - seems to have been a regression from the SDL1->SDL2 migration.

Some highlights:

* Tweaks in how the length is calculated from the ZZM parser to note frequency, to match some odd quirks that worlds might start using at some point.
* Tweaks in note frequency calculation - ZZT doesn't use A432, it actually uses scientific pitch! (C256, A430.56) Except it doesn't even do *that* - there's two rounding errors inbetween:
    * ZZT truncates the frequency, so 430.56Hz becomes 430Hz.
    * PIT square wave playback utilizes an integer divison of approximately the form (1193182 / x), which further distorts the desired frequency number.
* Copied over drum tables generated by ZZT 3.2 - they're a bit tricky to get right otherwise, so it's best to just hard-code them.

Note that at this point, it might be necessary to [add RoZ's MIT license](https://github.com/asiekierka/reconstruction-of-zzt/blob/master/LICENSE.TXT) for sparkling perfect legal compliance. (If you're not ready for/not comfortable with that, feel free to cherry-pick out the non-"Synth adjustments to match ZZT behaviour" commits; those are fine.)