### PR TITLE
Fix board movement regression caused by commit 479c13a5

### DIFF
--- a/src/libzzt2/board.c
+++ b/src/libzzt2/board.c
@@ -684,9 +684,15 @@ int zztWorldMoveBoard(ZZTworld *world, int src, int dest)
 	/* Free the copy! */
 	zztBoardFree(copy);
 
+	/* Make sure old curboard is compressed */
+	zztBoardCompress(&world->boards[world->cur_board]);
+
 	/* Restore variables */
 	world->cur_board = new_cur_board;
 	world->header->startboard = new_startboard;
+
+	/* Make sure curboard is decompressed */
+	zztBoardDecompress(&world->boards[world->cur_board]);
 
 	return 1;
 }


### PR DESCRIPTION
Turns out that by fixing a small bug, I caused a far larger bug!

Reproduction steps:

* Create a world with boards "Title Screen", "A", "B" and "C".
* Open board "C".
* Move "C" two boards up (above board "A").
* Try saving. A null pointer exception will occur.

In essence, when I added the code to only change cur_board/statboard at the end, I wasn't aware of the rule that all boards except the currently opened one must be compressed - and so the resulting state was not what the engine expected.

Perhaps a better fix would be to make zztBoardWrite/etc. take care of the compression status, but this gets the job done fairly non-invasively.