### PR TITLE
Board linking/param-related tweaks

### DIFF
--- a/src/dialogs/infobox.c
+++ b/src/dialogs/infobox.c
@@ -417,27 +417,51 @@ int boardinfodeltaoption(displaymethod * d, ZZTworld* myworld, dialogComponent* 
 			return 1;
 
 		case BRDINFO_BRDNORTH:
-			if (info->board_n + delta <= zztWorldGetBoardcount(myworld) &&
-					info->board_n + delta >= 0)
+			if (info->board_n + delta >= zztWorldGetBoardcount(myworld) ) {
+				info->board_n = zztWorldGetBoardcount(myworld) - 1;
+			}
+			else if( info->board_n + delta < 0) {
+				info->board_n = 0;
+			}
+			else {
 				info->board_n += delta;
+			}
 			return 1;
 
 		case BRDINFO_BRDSOUTH:
-			if (info->board_s + delta <= zztWorldGetBoardcount(myworld) &&
-					info->board_s + delta >= 0)
+			if (info->board_s + delta >= zztWorldGetBoardcount(myworld) ) {
+				info->board_s = zztWorldGetBoardcount(myworld) - 1;
+			}
+			else if( info->board_s + delta < 0) {
+				info->board_s = 0;
+			}
+			else {
 				info->board_s += delta;
+			}
 			return 1;
 
 		case BRDINFO_BRDEAST:
-			if (info->board_e + delta <= zztWorldGetBoardcount(myworld) &&
-					info->board_e + delta >= 0)
+			if (info->board_e + delta >= zztWorldGetBoardcount(myworld) ) {
+				info->board_e = zztWorldGetBoardcount(myworld) - 1;
+			}
+			else if( info->board_e + delta < 0) {
+				info->board_e = 0;
+			}
+			else {
 				info->board_e += delta;
+			}
 			return 1;
 
 		case BRDINFO_BRDWEST:
-			if (info->board_w + delta <= zztWorldGetBoardcount(myworld) &&
-					info->board_w + delta >= 0)
+			if (info->board_w + delta >= zztWorldGetBoardcount(myworld) ) {
+				info->board_w = zztWorldGetBoardcount(myworld) - 1;
+			}
+			else if( info->board_w + delta < 0) {
+				info->board_w = 0;
+			}
+			else {
 				info->board_w += delta;
+			}
 			return 1;
 
 		default:

--- a/src/libzzt2/params.c
+++ b/src/libzzt2/params.c
@@ -31,7 +31,7 @@
 const ZZTprofile _zzt_param_profile_table[] = {
 	/* Type                  { properties, default cycle, data uses } */
 	/* ZZT_EMPTY          */ { 0, 0, { 0, 0, 0 } },
-	/* ZZT_EDGE           */ { 0, 0, { 0, 0, 0 } },   /* TODO: are edges paramless? */
+	/* ZZT_EDGE           */ { 0, 0, { 0, 0, 0 } },
 	/* ZZT_MESSAGETIMER   */ { 0, 0, { 0, 0, 0 } },
 	/* ZZT_MONITOR        */ { ZZT_PROPERTY_CYCLE, 1, { 0, 0, 0 } },
 	/* ZZT_PLAYER         */ { ZZT_PROPERTY_CYCLE, 1, { 0, 0, 0 } },
@@ -43,9 +43,9 @@ const ZZTprofile _zzt_param_profile_table[] = {
 	/* ZZT_SCROLL         */ { ZZT_PROPERTY_CYCLE | ZZT_PROPERTY_PROGRAM, 1, { 0, 0, 0 } },
 	/* ZZT_PASSAGE        */ { ZZT_PROPERTY_NONE, 0, { 0, 0, ZZT_DATAUSE_PASSAGEDEST } },
 	/* ZZT_DUPLICATOR     */ { ZZT_PROPERTY_STEP, 1, { 0, ZZT_DATAUSE_DUPRATE, 0 } },
-	/* ZZT_BOMB           */ { ZZT_PROPERTY_CYCLE, 6, { ZZT_DATAUSE_TIMELEFT, 0, 0 } },   /* TODO: there must be more to it than this */
+	/* ZZT_BOMB           */ { ZZT_PROPERTY_CYCLE, 6, { ZZT_DATAUSE_TIMELEFT, 0, 0 } },
 	/* ZZT_ENERGIZER      */ { 0, 0, { 0, 0, 0 } },
-	/* ZZT_STAR           */ { ZZT_PROPERTY_STEP | ZZT_PROPERTY_CYCLE, 1, { ZZT_DATAUSE_OWNER, 0, 0 } }, /* TODO: does owner matter? */
+	/* ZZT_STAR           */ { ZZT_PROPERTY_STEP | ZZT_PROPERTY_CYCLE, 1, { 0, 0, 0 } },
 	/* ZZT_CWCONV         */ { ZZT_PROPERTY_CYCLE, 3, { 0, 0, 0 } },
 	/* ZZT_CCWCONV        */ { ZZT_PROPERTY_CYCLE, 2, { 0, 0, 0 } },
 	/* ZZT_BULLET         */ { ZZT_PROPERTY_STEP | ZZT_PROPERTY_CYCLE, 1, { ZZT_DATAUSE_OWNER, 0, 0 } },


### PR DESCRIPTION
* Fixed bounds checking in board link selector (left/right/plus/minus) (rabbitboots)
* Made -/+ actually work in paramed.
* Made firing rate, projectiles and passage destinations changeable via left/right/-/+.
* Made firing rate show up as slider (like intelligence etc.)
* Resolved TODOs in params.c, hid star owner param from the end user.