### PR TITLE
Properly treat ZZT values as signed, where applicable.

### DIFF
--- a/src/dialogs/infobox.c
+++ b/src/dialogs/infobox.c
@@ -356,7 +356,7 @@ int boardinfoeditoption(displaymethod * d, ZZTworld* myworld, dialogComponent* o
 		case BRDINFO_MAXSHOTS:
 			if (opt->text[0] == '0') /* If the number is zero */
 				opt->text[0] = '\x0';  /* Clear the text */
-            edit_result = dialogComponentEdit(d, opt, 3, LINED_NOALPHA | LINED_NOPUNCT | LINED_NOSPACES);
+            edit_result = dialogComponentEdit(d, opt, 3, LINED_NUMBER);
 			if (edit_result == LINED_OK) {
 				int number;
 				sscanf(opt->text, "%d", &number);
@@ -381,7 +381,7 @@ int boardinfoeditoption(displaymethod * d, ZZTworld* myworld, dialogComponent* o
 				d->print(opt->x + 9, opt->y + 6, 0x00, "          ");
 			}
 
-			edit_result = dialogComponentEdit(d, opt, 5, LINED_NOALPHA | LINED_NOPUNCT | LINED_NOSPACES);
+			edit_result = dialogComponentEdit(d, opt, 5, LINED_NUMBER);
             if (edit_result == LINED_OK) {
 				long int timelimit;
 				sscanf(opt->text, "%ld", &timelimit);
@@ -738,49 +738,49 @@ int worldinfoeditoption(int curoption, ZZTworld* myworld,
 
 		case WLDINFO_AMMO:
 			tempnum = header->ammo;
-			lined_result = line_editnumber(cursorx, cursory, 0x0f, &tempnum, 32767, d);
+			lined_result = line_editsnumber(cursorx, cursory, 0x0f, &tempnum, -32768, 32767, d);
 			header->ammo = tempnum;
 			break;
 
 		case WLDINFO_GEMS:
 			tempnum = header->gems;
-			lined_result = line_editnumber(cursorx, cursory, 0x0f, &tempnum, 32767, d);
+			lined_result = line_editsnumber(cursorx, cursory, 0x0f, &tempnum, -32768, 32767, d);
 			header->gems = tempnum;
 			break;
 
 		case WLDINFO_HEALTH:
 			tempnum = header->health;
-			lined_result = line_editnumber(cursorx, cursory, 0x0f, &tempnum, 32767, d);
+			lined_result = line_editsnumber(cursorx, cursory, 0x0f, &tempnum, -32768, 32767, d);
 			header->health = tempnum;
 			break;
 
 		case WLDINFO_TORCHES:
 			tempnum = header->torches;
-			lined_result = line_editnumber(cursorx, cursory, 0x0f, &tempnum, 32767, d);
+			lined_result = line_editsnumber(cursorx, cursory, 0x0f, &tempnum, -32768, 32767, d);
 			header->torches = tempnum;
 			break;
 
 		case WLDINFO_SCORE:
 			tempnum = header->score;
-			lined_result = line_editnumber(cursorx, cursory, 0x0f, &tempnum, 32767, d);
+			lined_result = line_editsnumber(cursorx, cursory, 0x0f, &tempnum, -32768, 32767, d);
 			header->score = tempnum;
 			break;
 
 		case WLDINFO_TCYCLES:
 			tempnum = header->torchcycles;
-			lined_result = line_editnumber(cursorx, cursory, 0x0f, &tempnum, 32767, d);
+			lined_result = line_editsnumber(cursorx, cursory, 0x0f, &tempnum, -32768, 32767, d);
 			header->torchcycles = tempnum;
 			break;
 
 		case WLDINFO_ECYCLES:
 			tempnum = header->energizercycles;
-			lined_result = line_editnumber(cursorx, cursory, 0x0f, &tempnum, 32767, d);
+			lined_result = line_editsnumber(cursorx, cursory, 0x0f, &tempnum, -32768, 32767, d);
 			header->energizercycles = tempnum;
 			break;
 
 		case WLDINFO_TIMEPASSED:
 			tempnum = header->timepassed;
-			lined_result = line_editnumber(cursorx, cursory, 0x0f, &tempnum, 32767, d);
+			lined_result = line_editsnumber(cursorx, cursory, 0x0f, &tempnum, -32768, 32767, d);
 			header->timepassed = tempnum;
 			break;
 	}

--- a/src/dialogs/paramed.h
+++ b/src/dialogs/paramed.h
@@ -57,12 +57,12 @@ ZZTparam svectortoprogram(stringvector sv);
 /* getdirection(xstep, ystep)
  * Get a direction based on x and y step values
  */
-int getdirection(char xstep, char ystep);
+int getdirection(short xstep, short ystep);
 
 /* getxystep(xstep, ystep, dir)
  * Determines xstep and ystep from given direction
  */
-void getxystep(char * xstep, char * ystep, int dir);
+void getxystep(short * xstep, short * ystep, int dir);
 
 /* nextdirection(dir)
  * Returns the next direction after that given

--- a/src/kevedit/screen.c
+++ b/src/kevedit/screen.c
@@ -174,11 +174,19 @@ int line_editor_raw(int x, int y, int color, char* str, int editwidth,
 int line_editnumber(int x, int y, int color, int * number, int maxval,
                     displaymethod* d)
 {
+	return line_editsnumber(x, y, color, number, 0, maxval, d);
+}
+
+int line_editsnumber(int x, int y, int color, int * number, int minval, int maxval,
+                    displaymethod* d)
+{
 	char* buffer;
 	int editwidth = 0;
 	int factor;
 
-	for (factor = 1; factor < maxval; factor *= 10)
+	for (factor = 1; factor < maxval && factor < -minval; factor *= 10)
+		editwidth++;
+	if (minval < 0)
 		editwidth++;
 
 	if (editwidth == 0)
@@ -188,10 +196,12 @@ int line_editnumber(int x, int y, int color, int * number, int maxval,
 
 	sprintf(buffer, "%d", *number);
 	int result = line_editor(x, y, color, buffer, editwidth,
-			LINED_NOALPHA | LINED_NOPUNCT | LINED_NOSPACES, d);
+			minval >= 0 ? LINED_NUMBER : LINED_SNUMBER, d);
 	if(result == LINED_OK) {
 		sscanf(buffer, "%d", number);
-		if (*number > maxval)
+		if (*number < minval)
+			*number = minval;
+		else if (*number > maxval)
 			*number = maxval;
 		free(buffer);
 		return LINED_OK;

--- a/src/kevedit/screen.h
+++ b/src/kevedit/screen.h
@@ -74,6 +74,10 @@ int line_editor(int x, int y, int color,
 int line_editnumber(int x, int y, int color, int * number, int maxval,
                     displaymethod* d);
 
+/* line_editsnumber() - uses line_editor to edit the given signed number */
+int line_editsnumber(int x, int y, int color, int * number, int minval, int maxval,
+                    displaymethod* d);
+
 /* line_editor_raw() - even more powerful line editor, requires careful
  *                     handling
  * 	position: position in the string of the cursor

--- a/src/libzzt2/board.c
+++ b/src/libzzt2/board.c
@@ -815,7 +815,7 @@ void zztBoardSetMessage(ZZTworld *world, char *message)
 	strncpy((char *)world->boards[world->cur_board].info.message, message, ZZT_MESSAGE_SIZE);
 	world->boards[world->cur_board].info.message[ZZT_MESSAGE_SIZE] = '\0';
 }
-void zztBoardSetTimelimit(ZZTworld *world, uint16_t timelimit)
+void zztBoardSetTimelimit(ZZTworld *world, int16_t timelimit)
 {
 	world->boards[world->cur_board].info.timelimit = timelimit;
 }
@@ -869,7 +869,7 @@ uint8_t *zztBoardGetMessage(ZZTworld *world)
 {
 	return world->boards[world->cur_board].info.message;
 }
-uint16_t zztBoardGetTimelimit(ZZTworld *world)
+int16_t zztBoardGetTimelimit(ZZTworld *world)
 {
 	return world->boards[world->cur_board].info.timelimit;
 }

--- a/src/libzzt2/file.c
+++ b/src/libzzt2/file.c
@@ -116,9 +116,8 @@ int zztWorldWrite(ZZTworld *world, FILE *fp)
 	_zzt_outw_ordie(&world->header->torches, fp);
 	_zzt_outw_ordie(&world->header->torchcycles, fp);
 	_zzt_outw_ordie(&world->header->energizercycles, fp);
-	/* Unknown: next 2 */
-	_zzt_outb_ordie(&world->header->magic1[0], fp);	/* TODO */
-	_zzt_outb_ordie(&world->header->magic1[1], fp);	/* XXX */
+	w = 0; /* Unused */
+	_zzt_outw_ordie(&w, fp);
 	_zzt_outw_ordie(&world->header->score, fp);
 	b = strlen((char *)world->header->title);
 	_zzt_outb_ordie(&b, fp);
@@ -135,9 +134,7 @@ int zztWorldWrite(ZZTworld *world, FILE *fp)
 	}
 	/* More header */
 	_zzt_outw_ordie(&world->header->timepassed, fp);
-	/* Unknown: next 2 */
-	_zzt_outb_ordie(&world->header->magic2[0], fp);	/* TODO */
-	_zzt_outb_ordie(&world->header->magic2[1], fp);	/* XXX */
+	_zzt_outw_ordie(&world->header->timepassedhsec, fp);
 	_zzt_outb_ordie(&world->header->savegame, fp);
 	_zzt_outspad_ordie(NULL, 0, 247, fp);
 	/* Write boards */
@@ -157,7 +154,7 @@ ZZTworld *zztWorldRead(FILE *fp)
 	int i;
 
 	uint8_t len;
-	uint16_t bcount;
+	uint16_t bcount, unusedw;
 
 	/* Read & check header */
 	_zzt_inb_or(&magicnumber[0], fp) return NULL;
@@ -184,9 +181,8 @@ ZZTworld *zztWorldRead(FILE *fp)
 	_zzt_inw_or(&world->header->torches, fp) freeworld;
 	_zzt_inw_or(&world->header->torchcycles, fp) freeworld;
 	_zzt_inw_or(&world->header->energizercycles, fp) freeworld;
-	/* Unknown: next 2 */
-	_zzt_inb_or(&world->header->magic1[0], fp) freeworld; /* TODO */
-	_zzt_inb_or(&world->header->magic1[1], fp) freeworld; /* XXX */
+	/* Unused */
+	_zzt_inb_or(&unusedw, fp) freeworld;
 	_zzt_inw_or(&world->header->score, fp) freeworld;
 	_zzt_inb_or(&len, fp) freeworld;
 	if(len > ZZT_WORLD_TITLE_SIZE)
@@ -202,9 +198,7 @@ ZZTworld *zztWorldRead(FILE *fp)
 	}
 	/* More header */
 	_zzt_inw_or(&world->header->timepassed, fp) freeworld;
-	/* Unknown: next 2 */
-	_zzt_inb_or(&world->header->magic2[0], fp) freeworld; /* TODO */
-	_zzt_inb_or(&world->header->magic2[1], fp) freeworld; /* XXX */
+	_zzt_inw_or(&world->header->timepassedhsec, fp) freeworld;
 	_zzt_inb_or(&world->header->savegame, fp) freeworld;
 	_zzt_inspad_or(NULL, 0, 247, fp) freeworld;
 	/* Read boards */

--- a/src/libzzt2/params.c
+++ b/src/libzzt2/params.c
@@ -150,8 +150,8 @@ ZZTparam *zztParamCreateBlank(void)
 	param->ystep = 0;
 	param->cycle = 0;
 	memset(param->data, 0, sizeof(param->data));
-	param->leaderindex = 0xFFFF;
-	param->followerindex = 0xFFFF;
+	param->leaderindex = -1;
+	param->followerindex = -1;
 	param->utype = ZZT_EMPTY;
 	param->ucolor = 0x0F;
 	memset(param->magic, 0, sizeof(param->magic));

--- a/src/libzzt2/tiles.c
+++ b/src/libzzt2/tiles.c
@@ -224,15 +224,15 @@ const uint8_t _zzt_display_char_line_table[] = {
  * references equal to start will be reset to their default value. */
 void _zzt_relink_param(ZZTparam * param, int start)
 {
-	if (param->leaderindex > start && param->leaderindex != 0xFFFF)
+	if (param->leaderindex > start && param->leaderindex != -1)
 		param->leaderindex--;
 	else if (param->leaderindex == start)
-		param->leaderindex = 0xFFFF;
+		param->leaderindex = -1;
 
-	if (param->followerindex > start && param->followerindex != 0xFFFF)
+	if (param->followerindex > start && param->followerindex != -1)
 		param->followerindex--;
 	else if (param->followerindex == start)
-		param->followerindex = 0xFFFF;
+		param->followerindex = -1;
 
 	if (param->bindindex > start)
 		param->bindindex--;
@@ -716,18 +716,18 @@ uint8_t zztLoneTileGetDisplayChar(ZZTtile tile)
 	switch (tile.type) {
 		case ZZT_TRANSPORTER:
 			if (tile.param == NULL) break;
-			if (tile.param->xstep == 0xFFFF) return '<';
-			if (tile.param->xstep == 0x0001) return '>';
-			if (tile.param->ystep == 0xFFFF) return '^';
+			if (tile.param->xstep == -1) return '<';
+			if (tile.param->xstep == 1) return '>';
+			if (tile.param->ystep == -1) return '^';
 			return 'v';
 		case ZZT_OBJECT:
 			if (tile.param == NULL) break;
 			return tile.param->data[0];
 		case ZZT_PUSHER:
 			if (tile.param == NULL) break;
-			if (tile.param->xstep == 0xFFFF) return 17;
-			if (tile.param->xstep == 0x0001) return 16;
-			if (tile.param->ystep == 0xFFFF) return 30;
+			if (tile.param->xstep == -1) return 17;
+			if (tile.param->xstep == 1) return 16;
+			if (tile.param->ystep == -1) return 30;
 			return 31;
 	}
 

--- a/src/libzzt2/world.c
+++ b/src/libzzt2/world.c
@@ -139,11 +139,11 @@ void zztWorldSetBoardcount(ZZTworld *world, uint16_t count)
 	// XXX Don't ever use this, it's just here for completeness
 	world->header->boardcount = count;
 }
-void zztWorldSetAmmo(ZZTworld *world, uint16_t ammo)
+void zztWorldSetAmmo(ZZTworld *world, int16_t ammo)
 {
 	world->header->ammo = ammo;
 }
-void zztWorldSetGems(ZZTworld *world, uint16_t gems)
+void zztWorldSetGems(ZZTworld *world, int16_t gems)
 {
 	world->header->gems = gems;
 }
@@ -152,27 +152,27 @@ void zztWorldSetKey(ZZTworld *world, int number, uint8_t state)
 	if(number >= 0 && number < 7)
 		world->header->keys[number] = state;
 }
-void zztWorldSetHealth(ZZTworld *world, uint16_t health)
+void zztWorldSetHealth(ZZTworld *world, int16_t health)
 {
 	world->header->health = health;
 }
-void zztWorldSetStartboard(ZZTworld *world, uint16_t startboard)
+void zztWorldSetStartboard(ZZTworld *world, int16_t startboard)
 {
 	world->header->startboard = startboard;
 }
-void zztWorldSetTorches(ZZTworld *world, uint16_t torches)
+void zztWorldSetTorches(ZZTworld *world, int16_t torches)
 {
 	world->header->torches = torches;
 }
-void zztWorldSetTorchcycles(ZZTworld *world, uint16_t torchcycles)
+void zztWorldSetTorchcycles(ZZTworld *world, int16_t torchcycles)
 {
 	world->header->torchcycles = torchcycles;
 }
-void zztWorldSetEnergizercycles(ZZTworld *world, uint16_t energizercycles)
+void zztWorldSetEnergizercycles(ZZTworld *world, int16_t energizercycles)
 {
 	world->header->energizercycles = energizercycles;
 }
-void zztWorldSetScore(ZZTworld *world, uint16_t score)
+void zztWorldSetScore(ZZTworld *world, int16_t score)
 {
 	world->header->score = score;
 }
@@ -188,7 +188,7 @@ void zztWorldSetFlag(ZZTworld *world, int number, char *word)
 		world->header->flags[number][ZZT_FLAG_SIZE] = '\0';
 	}
 }
-void zztWorldSetTimepassed(ZZTworld *world, uint16_t time)
+void zztWorldSetTimepassed(ZZTworld *world, int16_t time)
 {
 	world->header->timepassed = time;
 }
@@ -207,11 +207,11 @@ uint16_t zztWorldGetBoardcount(ZZTworld *world)
 {
 	return world->header->boardcount;
 }
-uint16_t zztWorldGetAmmo(ZZTworld *world)
+int16_t zztWorldGetAmmo(ZZTworld *world)
 {
 	return world->header->ammo;
 }
-uint16_t zztWorldGetGems(ZZTworld *world)
+int16_t zztWorldGetGems(ZZTworld *world)
 {
 	return world->header->gems;
 }
@@ -221,27 +221,27 @@ uint8_t zztWorldGetKey(ZZTworld *world, int number)
 		return world->header->keys[number];
 	return -1;
 }
-uint16_t zztWorldGetHealth(ZZTworld *world)
+int16_t zztWorldGetHealth(ZZTworld *world)
 {
 	return world->header->health;
 }
-uint16_t zztWorldGetStartboard(ZZTworld *world)
+int16_t zztWorldGetStartboard(ZZTworld *world)
 {
 	return world->header->startboard;
 }
-uint16_t zztWorldGetTorches(ZZTworld *world)
+int16_t zztWorldGetTorches(ZZTworld *world)
 {
 	return world->header->torches;
 }
-uint16_t zztWorldGetTorchcycles(ZZTworld *world)
+int16_t zztWorldGetTorchcycles(ZZTworld *world)
 {
 	return world->header->torchcycles;
 }
-uint16_t zztWorldGetEnergizercycles(ZZTworld *world)
+int16_t zztWorldGetEnergizercycles(ZZTworld *world)
 {
 	return world->header->energizercycles;
 }
-uint16_t zztWorldGetScore(ZZTworld *world)
+int16_t zztWorldGetScore(ZZTworld *world)
 {
 	return world->header->score;
 }
@@ -255,7 +255,7 @@ uint8_t *zztWorldGetFlag(ZZTworld *world, int number)
 		return world->header->flags[number];
 	return NULL;
 }
-uint16_t zztWorldGetTimepassed(ZZTworld *world)
+int16_t zztWorldGetTimepassed(ZZTworld *world)
 {
 	return world->header->timepassed;
 }

--- a/src/libzzt2/zzt.h
+++ b/src/libzzt2/zzt.h
@@ -85,7 +85,7 @@ extern "C" {
 /* ZZT param profile -- description of tile with param data */
 typedef struct ZZTprofile {
 	uint8_t properties;
-	uint16_t cycledefault;
+	int16_t cycledefault;
 	int datause[3];
 } ZZTprofile;
 
@@ -101,7 +101,7 @@ typedef struct ZZTboardinfo {
 	uint8_t message[ZZT_MESSAGE_SIZE+1];	/* Board message */
 	uint8_t reenter_x;	/* Reenter x-coord */
 	uint8_t reenter_y;	/* Reenter y-coord */
-	uint16_t timelimit;	/* Time limit for board */
+	int16_t timelimit;	/* Time limit for board */
 	uint16_t paramcount;	/* How many parameter records on board */
 } ZZTboardinfo;
 
@@ -112,12 +112,12 @@ typedef struct ZZTparam {
 	uint8_t index;   /* Position of param in list */
 	uint8_t x;		/* X position */
 	uint8_t y;		/* Y position */
-	uint16_t xstep;	/* X step */
-	uint16_t ystep;	/* Y step */
-	uint16_t cycle;	/* Cycle (speed) */
+	int16_t xstep;	/* X step */
+	int16_t ystep;	/* Y step */
+	int16_t cycle;	/* Cycle (speed) */
 	uint8_t data[3];	/* Generic data */
-	uint16_t leaderindex;	/* Index of leader (usually for centipedes, -1 if none) */
-	uint16_t followerindex;	/* Index of follower (centipedes, -1 if none) */
+	int16_t leaderindex;	/* Index of leader (usually for centipedes, -1 if none) */
+	int16_t followerindex;	/* Index of follower (centipedes, -1 if none) */
 	uint8_t utype;		/* Type of tile underneath */
 	uint8_t ucolor;	/* Color of tile underneath */
 	uint8_t magic[4];	/* UNKNOWN */
@@ -162,20 +162,19 @@ typedef struct ZZTboard {
 /* ZZT world info -- stuff from the ZZT file header */
 typedef struct ZZTworldinfo {
 	uint16_t boardcount;	/* Boards in world */
-	uint16_t ammo;		/* Ammo count */
-	uint16_t gems;		/* Gems count */
+	int16_t ammo;		/* Ammo count */
+	int16_t gems;		/* Gems count */
 	uint8_t keys[7];	/* Keys */
-	uint16_t health;	/* Health count */
-	uint16_t startboard;	/* Number of board to start on */
-	uint16_t torches;	/* Torch count */
-	uint16_t torchcycles;	/* How many cycles of torch left */
-	uint16_t energizercycles; /* How many cycles of energizer left */
-	uint8_t magic1[2];	/* UNKNOWN */
-	uint16_t score;	/* Score */
+	int16_t health;		/* Health count */
+	int16_t startboard;	/* Number of board to start on */
+	int16_t torches;	/* Torch count */
+	int16_t torchcycles;	/* How many cycles of torch left */
+	int16_t energizercycles; /* How many cycles of energizer left */
+	int16_t score;		/* Score */
 	uint8_t title[ZZT_WORLD_TITLE_SIZE+1];	/* World title */
 	uint8_t flags[ZZT_MAX_FLAGS][ZZT_FLAG_SIZE+1];	/* 10 flags, 20 chars each */
-	uint16_t timepassed;	/* Time passed in savegame */
-	uint8_t magic2[2];	/* ALSO UNKNOWN */
+	int16_t timepassed;	/* Time passed in savegame */
+	int16_t timepassedhsec;	/* Internal 1/100th-seconds timer for passed time */
 	uint8_t savegame;	/* Set if savegame */
 } ZZTworldinfo;
 
@@ -226,18 +225,18 @@ uint32_t zztWorldGetSize(ZZTworld *world);
  * Set a world info variable
  */
 void zztWorldSetBoardcount(ZZTworld *world, uint16_t count);	/* Don't ever use */
-void zztWorldSetAmmo(ZZTworld *world, uint16_t ammo);
-void zztWorldSetGems(ZZTworld *world, uint16_t gems);
+void zztWorldSetAmmo(ZZTworld *world, int16_t ammo);
+void zztWorldSetGems(ZZTworld *world, int16_t gems);
 void zztWorldSetKey(ZZTworld *world, int number, uint8_t state);
-void zztWorldSetHealth(ZZTworld *world, uint16_t health);
-void zztWorldSetStartboard(ZZTworld *world, uint16_t startboard);
-void zztWorldSetTorches(ZZTworld *world, uint16_t torches);
-void zztWorldSetTorchcycles(ZZTworld *world, uint16_t torchcycles);
-void zztWorldSetEnergizercycles(ZZTworld *world, uint16_t energizercycles);
-void zztWorldSetScore(ZZTworld *world, uint16_t score);
+void zztWorldSetHealth(ZZTworld *world, int16_t health);
+void zztWorldSetStartboard(ZZTworld *world, int16_t startboard);
+void zztWorldSetTorches(ZZTworld *world, int16_t torches);
+void zztWorldSetTorchcycles(ZZTworld *world, int16_t torchcycles);
+void zztWorldSetEnergizercycles(ZZTworld *world, int16_t energizercycles);
+void zztWorldSetScore(ZZTworld *world, int16_t score);
 void zztWorldSetTitle(ZZTworld *world, char *title);
 void zztWorldSetFlag(ZZTworld *world, int number, char *word);
-void zztWorldSetTimepassed(ZZTworld *world, uint16_t time);
+void zztWorldSetTimepassed(ZZTworld *world, int16_t time);
 void zztWorldSetSavegame(ZZTworld *world, uint8_t flag);
 /* zztWorldSetFilename(world, name)
  * Set the filename of the world
@@ -247,18 +246,18 @@ void zztWorldSetFilename(ZZTworld *world, char *name);
  * Get a world info variable
  */
 uint16_t zztWorldGetBoardcount(ZZTworld *world);
-uint16_t zztWorldGetAmmo(ZZTworld *world);
-uint16_t zztWorldGetGems(ZZTworld *world);
+int16_t zztWorldGetAmmo(ZZTworld *world);
+int16_t zztWorldGetGems(ZZTworld *world);
 uint8_t zztWorldGetKey(ZZTworld *world, int number);
-uint16_t zztWorldGetHealth(ZZTworld *world);
-uint16_t zztWorldGetStartboard(ZZTworld *world);
-uint16_t zztWorldGetTorches(ZZTworld *world);
-uint16_t zztWorldGetTorchcycles(ZZTworld *world);
-uint16_t zztWorldGetEnergizercycles(ZZTworld *world);
-uint16_t zztWorldGetScore(ZZTworld *world);
+int16_t zztWorldGetHealth(ZZTworld *world);
+int16_t zztWorldGetStartboard(ZZTworld *world);
+int16_t zztWorldGetTorches(ZZTworld *world);
+int16_t zztWorldGetTorchcycles(ZZTworld *world);
+int16_t zztWorldGetEnergizercycles(ZZTworld *world);
+int16_t zztWorldGetScore(ZZTworld *world);
 uint8_t *zztWorldGetTitle(ZZTworld *world);
 uint8_t *zztWorldGetFlag(ZZTworld *world, int number);
-uint16_t zztWorldGetTimepassed(ZZTworld *world);
+int16_t zztWorldGetTimepassed(ZZTworld *world);
 uint8_t zztWorldGetSavegame(ZZTworld *world);
 /* zztWorldGetFilename(world)
  * Get the filename of the world
@@ -358,7 +357,7 @@ void zztBoardSetReenter(ZZTworld *world, uint8_t reenter);
 void zztBoardSetReenter_x(ZZTworld *world, uint8_t reenter_x);
 void zztBoardSetReenter_y(ZZTworld *world, uint8_t reenter_y);
 void zztBoardSetMessage(ZZTworld *world, char *message);
-void zztBoardSetTimelimit(ZZTworld *world, uint16_t timelimit);
+void zztBoardSetTimelimit(ZZTworld *world, int16_t timelimit);
 void zztBoardSetParamcount(ZZTworld *world, uint16_t paramcount);	/* Don't ever use */
 /* zztBoardGetXXXXX()
  * Get a board info variable
@@ -374,7 +373,7 @@ uint8_t zztBoardGetReenter(ZZTworld *world);
 uint8_t zztBoardGetReenter_x(ZZTworld *world);
 uint8_t zztBoardGetReenter_y(ZZTworld *world);
 uint8_t *zztBoardGetMessage(ZZTworld *world);
-uint16_t zztBoardGetTimelimit(ZZTworld *world);
+int16_t zztBoardGetTimelimit(ZZTworld *world);
 uint16_t zztBoardGetParamcount(ZZTworld *world);
 
 /***** FILE I/O ******/


### PR DESCRIPTION
* Adjust libzzt2's internal format to match ZZT's engine usage with regards to signedness and unusedness, as well as document "magic2".
* Make world info value and stat value bounds match what the ZZT engine processes in the editor. Time limit has been left alone, as it'd be a bit tricky to change while leaving the "Infinite" word handling as-is.
* Fix a crash in the centipede head/segment param editor if the leader/follower value is smaller than -1.
* Add bounds check to buildparamdescription() to prevent the above crash for leader/follower values higher than the stat count on a board.