### PR TITLE
Force zztPlotPlayer to place the player when moving stat 0. 

### DIFF
--- a/src/libzzt2/tiles.c
+++ b/src/libzzt2/tiles.c
@@ -559,18 +559,16 @@ int zztPlotPlayer(ZZTworld * world, int x, int y)
 {
 	ZZTboard* brd = zztBoardGetCurPtr(world);
 
-	/* Simple case */
-	if (x == brd->plx && y == brd->ply)
-		return 1;
-
 	/* Error if board cannot be decompressed */
 	if (!zztBoardDecompress(brd))
 		return 0;
 
-	zztTileMove(brd->bigboard, brd->plx, brd->ply, x, y);
+	if (x != brd->plx || y != brd->ply)
+		zztTileMove(brd->bigboard, brd->plx, brd->ply, x, y);
 
 	/* Record the change */
 	brd->plx = x; brd->ply = y;
+	zztTileAt(brd->bigboard, x, y).type = ZZT_PLAYER;
 
 	return 1;
 }


### PR DESCRIPTION
This solves the issue in https://github.com/cknave/kevedit/issues/34 , with the added caveat of always decompressing the board (in case the user is trying to plot the player at the location it was removed from).

See issue for more discussion about how to solve this problem - this is just "the easy way out".