### PR TITLE
Repurpose 'R' key for Reverse Colors

### DIFF
--- a/docs/kkeys.hlp
+++ b/docs/kkeys.hlp
@@ -22,7 +22,7 @@ INSERT
  q - Quits KevEdit
  n - Creates a new world
  z - Clears the current board
- r or ALT-T - Runs zzt
+ ALT-T - Runs zzt
  h - Help
  ! - Loads text editor
 CTRL-O
@@ -66,6 +66,7 @@ b - Switch/edit boards
 
  c - Cycles through foreground colors
  C - Cycles through background colors
+ r - Reverses foreground and background
  k - Kolor dialog
  v - Toggles blinking colors
  d - Toggles default color mode

--- a/src/kevedit/kevedit.c
+++ b/src/kevedit/kevedit.c
@@ -587,6 +587,23 @@ void keveditHandleKeypress(keveditor * myeditor)
 			pat_applycolordata(myeditor->buffers.standard_patterns, myeditor->color);
 			myeditor->updateflags |= UD_COLOR;
 			break;
+                case 'r':
+                case 'R':
+                        /* Reverse Colors */
+                        myeditor->color.fg = myeditor->color.fg + myeditor->color.bg;
+                        myeditor->color.bg = myeditor->color.fg - myeditor->color.bg;
+                        myeditor->color.fg = myeditor->color.fg - myeditor->color.bg;
+                        if (myeditor->color.blink == 1) {
+                                myeditor->color.fg = myeditor->color.fg + 8;
+                        }
+                        myeditor->color.blink = 0;
+                        if (myeditor->color.bg > 7) {
+                                myeditor->color.blink = 1;
+                                myeditor->color.bg = myeditor->color.bg - 8;
+                        }
+                        pat_applycolordata(myeditor->buffers.standard_patterns, myeditor->color);
+                        myeditor->updateflags |= UD_COLOR;
+                        break;
 		case 'k':
 		case 'K':
 		case DKEY_CTRL_K:
@@ -620,8 +637,6 @@ void keveditHandleKeypress(keveditor * myeditor)
 
 			myeditor->updateflags |= UD_ALL;
 			break;
-		case 'r':
-		case 'R':
 		case DKEY_ALT_T:  /* Alt-t (by popular demand) */
 			/* run zzt */
 			/* Load current world into zzt */


### PR DESCRIPTION
For your kind consideration, please consider repurposing the 'R' key for 'R'everse colors, an extremely useful keybind that I have been hacking into my own build of Kevedit for nearly 3 years.