### PR TITLE
Use CTRL as a modifier for moving between boards

### DIFF
--- a/docs/kkeys.hlp
+++ b/docs/kkeys.hlp
@@ -53,6 +53,10 @@ PAGEUP
   Previous Board
 PAGEDOWN
   Next Board
+CTRL+CURSOR KEYS
+  Switch to linked boards.
+CTRL+PAGEUP/PAGEDOWN
+  Skip 7 boards at once.
 b - Switch/edit boards
 
 :file;File Operations

--- a/src/display/display_sdl.c
+++ b/src/display/display_sdl.c
@@ -781,8 +781,32 @@ static int display_sdl_getkey()
 		/* If alpha key, return special ctrl+alpha */
 		if(event.key.keysym.sym >= SDLK_a && event.key.keysym.sym <= SDLK_z) {
 			event.key.keysym.sym -= 0x60;
+		} else {
+			switch(event.key.keysym.sym) {
+				case DKEY_PAGEUP:
+					event.key.keysym.sym = DKEY_CTRL_PAGEUP;
+					break;
+				case DKEY_PAGEDOWN:
+					event.key.keysym.sym = DKEY_CTRL_PAGEDOWN;
+					break;
+				case DKEY_LEFT:
+					event.key.keysym.sym = DKEY_CTRL_LEFT;
+					break;
+				case DKEY_RIGHT:
+					event.key.keysym.sym = DKEY_CTRL_RIGHT;
+					break;
+				case DKEY_UP:
+					event.key.keysym.sym = DKEY_CTRL_UP;
+					break;
+				case DKEY_DOWN:
+					event.key.keysym.sym = DKEY_CTRL_DOWN;
+					break;
+				default:
+					break;
+			}
 		}
 	}
+
 	/* Alt is down */
 	else if(event.key.keysym.mod & KMOD_ALT) {
 		switch(event.key.keysym.sym) {

--- a/src/display/keys.h
+++ b/src/display/keys.h
@@ -68,6 +68,14 @@
 #define DKEY_ALT_UP     (152 | DDOSKEY_EXT)
 #define DKEY_ALT_DOWN   (160 | DDOSKEY_EXT)
 
+/* Ctrl-arrow and PgUp/PgDn keys */
+#define DKEY_CTRL_PAGEUP (132 | DDOSKEY_EXT)
+#define DKEY_CTRL_PAGEDOWN (118 | DDOSKEY_EXT)
+#define DKEY_CTRL_LEFT   (115 | DDOSKEY_EXT)
+#define DKEY_CTRL_RIGHT  (116 | DDOSKEY_EXT)
+#define DKEY_CTRL_UP     (141 | DDOSKEY_EXT)
+#define DKEY_CTRL_DOWN   (145 | DDOSKEY_EXT)
+
 /* Ctrl-letter keys */
 #define DKEY_CTRL_A     ('a' - 0x60)
 #define DKEY_CTRL_B     ('b' - 0x60)

--- a/src/kevedit/kevedit.c
+++ b/src/kevedit/kevedit.c
@@ -508,7 +508,48 @@ void keveditHandleKeypress(keveditor * myeditor)
 
 			myeditor->updateflags |= UD_BOARD | UD_OBJCOUNT | UD_BOARDTITLE;
 			break;
+		case DKEY_PAGEUP:
+			/* Switch to previous board (bounds checking is automatic) */
+			zztBoardSelect(myeditor->myworld, zztBoardGetCurrent(myeditor->myworld) - 1);
 
+			myeditor->updateflags |= UD_BOARD | UD_OBJCOUNT | UD_BOARDTITLE;
+			break;
+		case DKEY_CTRL_PAGEDOWN:
+			/* Switch to next page of boards (bounds checking is automatic) */
+			zztBoardSelect(myeditor->myworld, zztBoardGetCurrent(myeditor->myworld) + 7);
+
+			myeditor->updateflags |= UD_BOARD | UD_OBJCOUNT | UD_BOARDTITLE;
+			break;
+		case DKEY_CTRL_PAGEUP:
+			/* Switch to previous page of boards (bounds checking is automatic) */
+			zztBoardSelect(myeditor->myworld, zztBoardGetCurrent(myeditor->myworld) - 7);
+
+			myeditor->updateflags |= UD_BOARD | UD_OBJCOUNT | UD_BOARDTITLE;
+			break;
+		case DKEY_CTRL_UP:
+			if (zztBoardGetBoard_n(myeditor->myworld) > 0) {
+				zztBoardSelect(myeditor->myworld, zztBoardGetBoard_n(myeditor->myworld));
+	                        myeditor->updateflags |= UD_BOARD | UD_OBJCOUNT | UD_BOARDTITLE;
+			}
+			break;
+		case DKEY_CTRL_DOWN:
+			if (zztBoardGetBoard_s(myeditor->myworld) > 0) {
+				zztBoardSelect(myeditor->myworld, zztBoardGetBoard_s(myeditor->myworld));
+				myeditor->updateflags |= UD_BOARD | UD_OBJCOUNT | UD_BOARDTITLE;
+			}
+			break;
+		case DKEY_CTRL_LEFT:
+			if (zztBoardGetBoard_w(myeditor->myworld) > 0) {
+				zztBoardSelect(myeditor->myworld, zztBoardGetBoard_w(myeditor->myworld));
+				myeditor->updateflags |= UD_BOARD | UD_OBJCOUNT | UD_BOARDTITLE;
+			}
+			break;
+		case DKEY_CTRL_RIGHT:
+			if (zztBoardGetBoard_e(myeditor->myworld) > 0) {
+				zztBoardSelect(myeditor->myworld, zztBoardGetBoard_e(myeditor->myworld));
+				myeditor->updateflags |= UD_BOARD | UD_OBJCOUNT | UD_BOARDTITLE;
+			}
+			break;
 		case 'i':
 		case 'I':
 			/* Board Info */

--- a/src/kevedit/kevedit.c
+++ b/src/kevedit/kevedit.c
@@ -508,12 +508,6 @@ void keveditHandleKeypress(keveditor * myeditor)
 
 			myeditor->updateflags |= UD_BOARD | UD_OBJCOUNT | UD_BOARDTITLE;
 			break;
-		case DKEY_PAGEUP:
-			/* Switch to previous board (bounds checking is automatic) */
-			zztBoardSelect(myeditor->myworld, zztBoardGetCurrent(myeditor->myworld) - 1);
-
-			myeditor->updateflags |= UD_BOARD | UD_OBJCOUNT | UD_BOARDTITLE;
-			break;
 		case DKEY_CTRL_PAGEDOWN:
 			/* Switch to next page of boards (bounds checking is automatic) */
 			zztBoardSelect(myeditor->myworld, zztBoardGetCurrent(myeditor->myworld) + 7);


### PR DESCRIPTION
This is another hack I have been using for a long time. CTRL + direction to move between linked boards and CTRL+PgUp / CTRL+PgDn to move the same number of boards as PgUp/PgDn moves you in the 'B'oard selector. It's intuitive and it makes checking the connections between rooms really easy.