### PR TITLE
Keyboard fixes

### DIFF
--- a/src/display/Makefile.am
+++ b/src/display/Makefile.am
@@ -4,7 +4,7 @@ AUTOMAKE_OPTIONS = 1.6.3
 
 noinst_LIBRARIES = libdisplay.a
 
-libdisplay_a_SOURCES = charset.c charset.h display.c display.h \
+libdisplay_a_SOURCES = casing.c casing.h charset.c charset.h display.c display.h \
 	display_stdio.c display_stdio.h textblock.c textblock.h keys.h colours.h \
 	palette.c palette.h
 

--- a/src/display/casing.c
+++ b/src/display/casing.c
@@ -1,0 +1,101 @@
+/* casing.h    -- Upper/lowercase functions for code page 437.
+ * Copyright (C) 2023 Kristofer Munsterhjelm <kristofer@munsterhjelm.no>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place Suite 330; Boston, MA 02111-1307, USA.
+ */
+
+const char cp437_uppercase[256] = {
+	'\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
+	'\x08', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E', '\x0F',
+	'\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17',
+	'\x18', '\x19', '\x1A', '\x1B', '\x1C', '\x1D', '\x1E', '\x1F',
+	'\x20', '\x21', '\x22', '\x23', '\x24', '\x25', '\x26', '\x27',
+	'\x28', '\x29', '\x2A', '\x2B', '\x2C', '\x2D', '\x2E', '\x2F',
+	'\x30', '\x31', '\x32', '\x33', '\x34', '\x35', '\x36', '\x37',
+	'\x38', '\x39', '\x3A', '\x3B', '\x3C', '\x3D', '\x3E', '\x3F',
+	'\x40', '\x41', '\x42', '\x43', '\x44', '\x45', '\x46', '\x47',
+	'\x48', '\x49', '\x4A', '\x4B', '\x4C', '\x4D', '\x4E', '\x4F',
+	'\x50', '\x51', '\x52', '\x53', '\x54', '\x55', '\x56', '\x57',
+	'\x58', '\x59', '\x5A', '\x5B', '\x5C', '\x5D', '\x5E', '\x5F',
+	'\x60', '\x41', '\x42', '\x43', '\x44', '\x45', '\x46', '\x47',
+	'\x48', '\x49', '\x4A', '\x4B', '\x4C', '\x4D', '\x4E', '\x4F',
+	'\x50', '\x51', '\x52', '\x53', '\x54', '\x55', '\x56', '\x57',
+	'\x58', '\x59', '\x5A', '\x7B', '\x7C', '\x7D', '\x7E', '\x7F',
+	'\x80', '\x9A', '\x90', '\x83', '\x8E', '\x85', '\x8F', '\x80',
+	'\x88', '\x89', '\x8A', '\x8B', '\x8C', '\x8D', '\x8E', '\x8F',
+	'\x90', '\x92', '\x92', '\x93', '\x99', '\x95', '\x96', '\x97',
+	'\x98', '\x99', '\x9A', '\x9B', '\x9C', '\x9D', '\x9E', '\x9F',
+	'\xA0', '\xA1', '\xA2', '\xA3', '\xA5', '\xA5', '\xA6', '\xA7',
+	'\xA8', '\xA9', '\xAA', '\xAB', '\xAC', '\xAD', '\xAE', '\xAF',
+	'\xB0', '\xB1', '\xB2', '\xB3', '\xB4', '\xB5', '\xB6', '\xB7',
+	'\xB8', '\xB9', '\xBA', '\xBB', '\xBC', '\xBD', '\xBE', '\xBF',
+	'\xC0', '\xC1', '\xC2', '\xC3', '\xC4', '\xC5', '\xC6', '\xC7',
+	'\xC8', '\xC9', '\xCA', '\xCB', '\xCC', '\xCD', '\xCE', '\xCF',
+	'\xD0', '\xD1', '\xD2', '\xD3', '\xD4', '\xD5', '\xD6', '\xD7',
+	'\xD8', '\xD9', '\xDA', '\xDB', '\xDC', '\xDD', '\xDE', '\xDF',
+	'\xE0', '\xE1', '\xE2', '\xE3', '\xE4', '\xE4', '\xE6', '\xE7',
+	'\xE8', '\xE9', '\xEA', '\xEB', '\xEC', '\xE8', '\xEE', '\xEF',
+	'\xF0', '\xF1', '\xF2', '\xF3', '\xF4', '\xF5', '\xF6', '\xF7',
+	'\xF8', '\xF9', '\xFA', '\xFB', '\xFC', '\xFD', '\xFE', '\xFF'
+};
+
+const char cp437_lowercase[256] = {
+	'\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
+	'\x08', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E', '\x0F',
+	'\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17',
+	'\x18', '\x19', '\x1A', '\x1B', '\x1C', '\x1D', '\x1E', '\x1F',
+	'\x20', '\x21', '\x22', '\x23', '\x24', '\x25', '\x26', '\x27',
+	'\x28', '\x29', '\x2A', '\x2B', '\x2C', '\x2D', '\x2E', '\x2F',
+	'\x30', '\x31', '\x32', '\x33', '\x34', '\x35', '\x36', '\x37',
+	'\x38', '\x39', '\x3A', '\x3B', '\x3C', '\x3D', '\x3E', '\x3F',
+	'\x40', '\x61', '\x62', '\x63', '\x64', '\x65', '\x66', '\x67',
+	'\x68', '\x69', '\x6A', '\x6B', '\x6C', '\x6D', '\x6E', '\x6F',
+	'\x70', '\x71', '\x72', '\x73', '\x74', '\x75', '\x76', '\x77',
+	'\x78', '\x79', '\x7A', '\x5B', '\x5C', '\x5D', '\x5E', '\x5F',
+	'\x60', '\x61', '\x62', '\x63', '\x64', '\x65', '\x66', '\x67',
+	'\x68', '\x69', '\x6A', '\x6B', '\x6C', '\x6D', '\x6E', '\x6F',
+	'\x70', '\x71', '\x72', '\x73', '\x74', '\x75', '\x76', '\x77',
+	'\x78', '\x79', '\x7A', '\x7B', '\x7C', '\x7D', '\x7E', '\x7F',
+	'\x87', '\x81', '\x82', '\x83', '\x84', '\x85', '\x86', '\x87',
+	'\x88', '\x89', '\x8A', '\x8B', '\x8C', '\x8D', '\x84', '\x86',
+	'\x82', '\x91', '\x91', '\x93', '\x94', '\x95', '\x96', '\x97',
+	'\x98', '\x94', '\x81', '\x9B', '\x9C', '\x9D', '\x9E', '\x9F',
+	'\xA0', '\xA1', '\xA2', '\xA3', '\xA4', '\xA4', '\xA6', '\xA7',
+	'\xA8', '\xA9', '\xAA', '\xAB', '\xAC', '\xAD', '\xAE', '\xAF',
+	'\xB0', '\xB1', '\xB2', '\xB3', '\xB4', '\xB5', '\xB6', '\xB7',
+	'\xB8', '\xB9', '\xBA', '\xBB', '\xBC', '\xBD', '\xBE', '\xBF',
+	'\xC0', '\xC1', '\xC2', '\xC3', '\xC4', '\xC5', '\xC6', '\xC7',
+	'\xC8', '\xC9', '\xCA', '\xCB', '\xCC', '\xCD', '\xCE', '\xCF',
+	'\xD0', '\xD1', '\xD2', '\xD3', '\xD4', '\xD5', '\xD6', '\xD7',
+	'\xD8', '\xD9', '\xDA', '\xDB', '\xDC', '\xDD', '\xDE', '\xDF',
+	'\xE0', '\xE1', '\xE2', '\xE3', '\xE5', '\xE5', '\xE6', '\xE7',
+	'\xE8', '\xE9', '\xEA', '\xEB', '\xEC', '\xED', '\xEE', '\xEF',
+	'\xF0', '\xF1', '\xF2', '\xF3', '\xF4', '\xF5', '\xF6', '\xF7',
+	'\xF8', '\xF9', '\xFA', '\xFB', '\xFC', '\xFD', '\xFE', '\xFF'
+};
+
+char tocupper(int c)
+{
+	if (c >= 0 && c < 256)
+		return cp437_uppercase[c];
+	return c;
+}
+
+char toclower(int c)
+{
+	if (c >= 0 && c < 256)
+		return cp437_lowercase[c];
+	return c;
+}

--- a/src/display/casing.h
+++ b/src/display/casing.h
@@ -1,0 +1,35 @@
+/* casing.h    -- Upper/lowercase functions for code page 437.
+ * Copyright (C) 2023 Kristofer Munsterhjelm <kristofer@munsterhjelm.no>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place Suite 330; Boston, MA 02111-1307, USA.
+ */
+
+#ifndef CASING_H
+#define CASING_H 1
+
+/* Note that the following tables follow the unicode.c convention that
+   uppercase phi is theta, to simulate ø and Ø. */
+
+/* The corresponding uppercase code page 437 character for any CP437 character */
+extern const char cp437_uppercase[256];
+
+/* The corresponding lowercase code page 437 character for any CP437 character */
+extern const char cp437_uppercase[256];
+
+/* Uppercasing and lowercasing functions */
+char tocupper(int c);
+char toclower(int c);
+
+#endif

--- a/src/display/display_sdl.c
+++ b/src/display/display_sdl.c
@@ -608,19 +608,9 @@ static int has_unicode_event_queued()
    to ALT+TAB not being properly handled on some Linux wms. */
 static void clear_event(SDL_EventType event_type)
 {
-	const int MAX_EVENTS = 10;
-	SDL_Event outevent[MAX_EVENTS];
-	int pending_events = SDL_PeepEvents(outevent,
-		MAX_EVENTS, SDL_PEEKEVENT, event_type,
-		event_type);
-
-	if (pending_events == 0)
-		return;
-
-	SDL_PeepEvents(outevent, 1, SDL_GETEVENT,
+	SDL_Event outevent;
+	SDL_PeepEvents(&outevent, 1, SDL_GETEVENT,
 		event_type, event_type);
-
-	return;
 }
 
 static int display_sdl_getkey()

--- a/src/kevedit/kevedit.c
+++ b/src/kevedit/kevedit.c
@@ -245,7 +245,7 @@ void keveditHandleSelection(keveditor * myeditor)
 	/* Block selection is based on whether the shift key is down */
 	int selectblockflag = myeditor->mydisplay->shift();
 
-	/* Except for shift + ASCII key */
+	/* Except for shift + literal key */
 	if (is_literal_key(myeditor->key) || myeditor->key == DKEY_SHIFT_TAB)
 		selectblockflag = 0;
 

--- a/src/kevedit/screen.c
+++ b/src/kevedit/screen.c
@@ -35,6 +35,7 @@
 #include "themes/theme.h"
 
 #include "display/display.h"
+#include "display/casing.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -136,12 +137,7 @@ int line_editor_raw(int x, int y, int color, char* str, int editwidth,
 			default:
 				/* Keys outside the standard ASCII range are returned for
 				 * consideration by the calling function */
-				/* NOTE: Turning this into is_literal_key wouldn't work because
-				   toupper etc have no idea of what cp437-specific letters are,
-				   e.g. that the cp437 equivalent of æ, when uppercased, is Æ.
-				   This is a known limitation, but doesn't seem to have much
-				   of an effect in practice. -KM */
-				if (!is_ascii_key(key)) {
+				if (!is_literal_key(key)) {
 					*position = pos;
 					return key;
 				}
@@ -164,8 +160,8 @@ int line_editor_raw(int x, int y, int color, char* str, int editwidth,
 																				 key == '<'  || key == '>' || key == '|')) break;
 				if ((flags & LINED_NOPATH)   && (key == '\\' || key == '/' || key == ':')) break;
 
-				if (flags & LINED_NOUPPER) key = tolower(key);
-				if (flags & LINED_NOLOWER) key = toupper(key);
+				if (flags & LINED_NOUPPER) key = toclower(key);
+				if (flags & LINED_NOLOWER) key = tocupper(key);
 
 				/* Insert character */
 				for (i = strlen(str) + 1; i > pos; i--)

--- a/src/kevedit/screen.h
+++ b/src/kevedit/screen.h
@@ -81,7 +81,7 @@ int line_editsnumber(int x, int y, int color, int * number, int minval, int maxv
 /* line_editor_raw() - even more powerful line editor, requires careful
  *                     handling
  * 	position: position in the string of the cursor
- * 	return:   whenever a control or non-ascii keypress occurs, it's value is
+ * 	return:   whenever a control or non-literal keypress occurs, it's value is
  * 	          returned */
 int line_editor_raw(int x, int y, int color, char* str, int editwidth,
 										int* position, int flags, displaymethod* d);

--- a/src/texteditor/editbox.c
+++ b/src/texteditor/editbox.c
@@ -39,6 +39,7 @@
 
 #include "libzzt2/zztoop.h"
 
+#include "display/casing.h"
 #include "display/display.h"
 #include "display/colours.h"
 
@@ -412,9 +413,8 @@ int editbox(char *title, stringvector * sv, int editwidth, int flags, displaymet
 								continue;
 							if (loopstr->s[0] == '!' && strlen(loopstr->s) >= 2)
 								tmpstr = loopstr->s + 1;
-							// toupper doesn't know about CP437-specific keys.
-							if (is_ascii_key(key) &&
-								(toupper(tmpstr[0]) == toupper(key))) {
+							if (is_literal_key(key) &&
+								(tocupper(tmpstr[0]) == tocupper(key))) {
 								centerstr = loopstr;
 								if (pos > strlen(centerstr->s))
 									pos = strlen(centerstr->s);

--- a/src/texteditor/select.c
+++ b/src/texteditor/select.c
@@ -126,7 +126,7 @@ void texteditHandleSelection(texteditor * editor)
 	/* Selection is based on whether the shift key is down */
 	editor->selectflag = editor->d->shift();
 
-	/* Except that shift + ASCII key does not start selection mode */
+	/* Except that shift + literal key does not start selection mode */
 	if (is_literal_key(editor->key))
 		editor->selectflag = 0;
 


### PR DESCRIPTION
This should fix #40 and also allows the use of international characters in things like board names, by creating CP437-specific variants of toupper() and tolower().

Things to note: the new files for upper/lowercase may not be in the right spot (src/display?), and hotkeys that aren't bound still removes literals (see the commit for more info).