### PR TITLE
Text handling

### DIFF
--- a/src/kevedit/kevedit.c
+++ b/src/kevedit/kevedit.c
@@ -353,16 +353,11 @@ void keveditHandleTextEntry(keveditor * myeditor)
 		/* Insert the current keystroke as text */
 		ZZTtile textTile = { ZZT_BLUETEXT, 0x00, NULL };
 
-		/* Determine the text code based on the FG colour */
-		if (myeditor->color.fg == 0 || myeditor->color.fg == 8 || myeditor->color.fg == 15)
-			textTile.type += 6;
-		else if (myeditor->color.fg > 8)
-			textTile.type += myeditor->color.fg - 9;
-		else
-			textTile.type += myeditor->color.fg - 1;
-
-		/* Determine color based on keypress */
+		/* Determine appearance (encoded as color) based on keypress */
 		textTile.color = key;
+
+		/* Set color */
+		encodetilecolor(&textTile, myeditor->color);
 
 		/* ASCII selection dialog */
 		if (key == DKEY_CTRL_A) {

--- a/src/kevedit/kevedit.c
+++ b/src/kevedit/kevedit.c
@@ -841,17 +841,26 @@ void keveditHandleKeypress(keveditor * myeditor)
 			myeditor->updateflags |= UD_TEXTMODE;
 			break;
 
-		case DKEY_ENTER:
+		case DKEY_ENTER: {
 			/* Modify / Grab */
 			next_key = modifyparam(myeditor->mydisplay, myeditor->myworld, myeditor->cursorx, myeditor->cursory);
 
-			/* TODO: if the current tile is text, edit the char */
+			/* If the current tile is text, edit the char */
+			ZZTtile tile = zztTileGet(myeditor->myworld, myeditor->cursorx, myeditor->cursory);
+			if (zztTileIsText(tile)) {
+				/* It's a text tile, open character selector to
+				 * change the character. */
+				tile.color = charselect(myeditor->mydisplay, tile.color);
+				/* And plot. */
+				zztPlot(myeditor->myworld, myeditor->cursorx, myeditor->cursory, tile);
+			}
 
 			/* When all is said and done, push the tile */
-			push(myeditor->buffers.backbuffer, zztTileGet(myeditor->myworld, myeditor->cursorx, myeditor->cursory));
+			push(myeditor->buffers.backbuffer, tile);
 
 			myeditor->updateflags |= UD_ALL;
 			break;
+		}
 
 		case DKEY_INSERT:
 			/* Insert */

--- a/src/kevedit/misc.c
+++ b/src/kevedit/misc.c
@@ -219,6 +219,31 @@ int pasteblock(ZZTblock *dest, ZZTblock *src, selection destsel, selection srcse
 	return 1;
 }
 
+/* Input is a text tile. Its color will be set to the foreground
+ * color of the variable "color" as closely as possible.*/
+void encodetextcolor(ZZTtile * text, textcolor color)
+{
+	text->type = ZZT_BLUETEXT;
+
+	/* Determine the text code based on the FG colour */
+	if (color.fg == 0 || color.fg == 8 || color.fg == 15) {
+		text->type += 6;
+	} else if (color.fg > 8) {
+		text->type += color.fg - 9;
+	} else {
+		text->type += color.fg - 1;
+	}
+}
+
+void encodetilecolor(ZZTtile * tile, textcolor color)
+{
+	if(zztTileIsText(*tile)) {
+		encodetextcolor(tile, color);
+	} else {
+		tile->color = encodecolor(color);
+	}
+}
+
 void plot(keveditor * myeditor)
 {
 	patbuffer* pbuf = myeditor->buffers.pbuf;
@@ -226,7 +251,7 @@ void plot(keveditor * myeditor)
 
 	/* Change the color to reflect state of default color mode */
 	if (myeditor->defcmode == 0) {
-		pattern.color = encodecolor(myeditor->color);
+		encodetilecolor(&pattern, myeditor->color);
 	}
 
 	zztPlot(myeditor->myworld, myeditor->cursorx, myeditor->cursory, pattern);

--- a/src/kevedit/misc.h
+++ b/src/kevedit/misc.h
@@ -39,6 +39,9 @@ int paste(keveditor * myeditor);
 int countparams(ZZTblock *block);
 int pasteblock(ZZTblock *dest, ZZTblock *src, selection destsel, selection srcsel, int x, int y);
 
+/* Change a tile's color, taking text into account */
+void encodetilecolor(ZZTtile * tile, textcolor color);
+
 /* Plot from the backbuffer to the cursor */
 void plot(keveditor * myeditor);
 

--- a/src/libzzt2/tiles.c
+++ b/src/libzzt2/tiles.c
@@ -822,3 +822,7 @@ const char * zztTileGetKind(ZZTtile tile)
 	return _zzt_type_kind_table[ZZT_WHITETEXT + 1];
 }
 
+int zztTileIsText(ZZTtile tile)
+{
+	return tile.type >= ZZT_BLUETEXT && tile.type <= ZZT_WHITETEXT;
+}

--- a/src/libzzt2/zzt.h
+++ b/src/libzzt2/zzt.h
@@ -532,6 +532,10 @@ const char * zztTileGetName(ZZTtile tile);
  */
 const char * zztTileGetKind(ZZTtile tile);
 
+/* zztTileIsText: returns true if the tile is text, false otherwise
+ * WARNING: Does not consider unsupported blinking text to be text! */
+int zztTileIsText(ZZTtile tile);
+
 /* Make the tile type name and kind tables visible (don't modify!) */
 extern const char * _zzt_type_name_table[];
 extern const char * _zzt_type_kind_table[];
@@ -594,7 +598,7 @@ extern const char * _zzt_type_kind_table[];
 
 #define ZZT_MAX_TYPE      0x35
 
-/* Kev probably made these up */
+/* Blinking text, usage may lead to undefined behavior in ZZT. */
 #define ZZT_BBLUETEXT     0x37
 #define ZZT_BGREENTEXT    0x38
 #define ZZT_BCYANTEXT     0x39


### PR DESCRIPTION
This makes the color adjustment when copying tiles change text tiles' color instead of their chars. It also implements a TODO where doing ENTER on a text tile shows the character selector and allows modifying the letter at that position.