### PR TITLE
Fix write to freed memory after deleting the last board.

### DIFF
--- a/src/libzzt2/board.c
+++ b/src/libzzt2/board.c
@@ -718,6 +718,11 @@ void zztBoardCommit(ZZTworld *world)
 {
 	int curboard = zztBoardGetCurrent(world);
 
+	/* Don't commit the last board if it was deleted. */
+	if (curboard >= world->header->boardcount) {
+		return;
+	}
+
 	/* Compress the current board */
 	zztBoardCompress(&(world->boards[curboard]));
 }


### PR DESCRIPTION
This doesn't seem to produce any immediate crashes in main, but valgrind reports an error, and it causes a more immediate crash in my bind-handling PR.

The bug can be reproduced by creating a new world, then a new board, making it the current board, deleting it in the selector, and then selecting the title screen.